### PR TITLE
Fail on out-of-order migrations instead of silently skipping

### DIFF
--- a/packages/cli/src/formatting.ts
+++ b/packages/cli/src/formatting.ts
@@ -159,6 +159,8 @@ function getStateColor(state: MigrationState): chalk.Chalk {
       return chalk.red;
     case 'MISSING':
       return chalk.red;
+    case 'IGNORED':
+      return chalk.red;
     case 'OUTDATED':
       return chalk.magenta;
     case 'ABOVE_BASELINE':

--- a/packages/core/src/__tests__/resolver.test.ts
+++ b/packages/core/src/__tests__/resolver.test.ts
@@ -342,4 +342,55 @@ describe('ResolveMigrations — out-of-order', () => {
     expect(result.PendingMigrations).toHaveLength(1);
     expect(result.PendingMigrations[0].Version).toBe('202701010000');
   });
+
+  it('does not mark earlier migrations as IGNORED on fresh DB with baseline', () => {
+    // Simulates the MJ scenario: v2, v3, v4, v5 migration folders.
+    // On a fresh database with baselineOnMigrate=true, the highest baseline
+    // is auto-selected. Migrations at/below the baseline should be ABOVE_BASELINE,
+    // migrations above should be PENDING. None should be IGNORED.
+    const discovered = [
+      // Baseline file (latest)
+      makeMigration({ Type: 'baseline', Version: '202601010000', Description: 'v5 Baseline' }),
+      // Old versioned migrations (v2, v3, v4 — below baseline)
+      makeMigration({ Version: '202301010000', Description: 'v2 Create Users' }),
+      makeMigration({ Version: '202401010000', Description: 'v3 Add Roles' }),
+      makeMigration({ Version: '202501010000', Description: 'v4 Add Permissions' }),
+      // New versioned migrations (v5 — above baseline)
+      makeMigration({ Version: '202601010001', Description: 'v5 Add Audit Log' }),
+      makeMigration({ Version: '202601020000', Description: 'v5 Add Notifications' }),
+    ];
+
+    // Fresh database — no applied history
+    const result = ResolveMigrations(discovered, [], '1', true, false);
+
+    // Baseline should be auto-selected
+    expect(result.BaselineAutoSelected).toBe(true);
+    expect(result.EffectiveBaselineVersion).toBe('202601010000');
+
+    // No migrations should be IGNORED
+    const ignored = result.StatusReport.filter((s) => s.State === 'IGNORED');
+    expect(ignored).toHaveLength(0);
+
+    // Old migrations should be ABOVE_BASELINE
+    const aboveBaseline = result.StatusReport.filter((s) => s.State === 'ABOVE_BASELINE');
+    expect(aboveBaseline).toHaveLength(3);
+    expect(aboveBaseline.map((s) => s.Version)).toEqual([
+      '202301010000',
+      '202401010000',
+      '202501010000',
+    ]);
+
+    // New migrations should be PENDING
+    const pending = result.StatusReport.filter(
+      (s) => s.State === 'PENDING' && s.Type === 'versioned'
+    );
+    expect(pending).toHaveLength(2);
+    expect(pending.map((s) => s.Version)).toEqual(['202601010001', '202601020000']);
+
+    // PendingMigrations should include baseline + 2 versioned
+    expect(result.PendingMigrations).toHaveLength(3);
+    expect(result.PendingMigrations[0].Type).toBe('baseline');
+    expect(result.PendingMigrations[1].Version).toBe('202601010001');
+    expect(result.PendingMigrations[2].Version).toBe('202601020000');
+  });
 });

--- a/packages/core/src/__tests__/resolver.test.ts
+++ b/packages/core/src/__tests__/resolver.test.ts
@@ -285,7 +285,7 @@ describe('ResolveMigrations — repeatable migrations', () => {
 });
 
 describe('ResolveMigrations — out-of-order', () => {
-  it('includes out-of-order migration in status but not pending when outOfOrder is false', () => {
+  it('marks out-of-order migration as IGNORED when outOfOrder is false', () => {
     const discovered = [
       makeMigration({ Version: '202401010000', Description: 'Old migration' }),
     ];
@@ -295,10 +295,51 @@ describe('ResolveMigrations — out-of-order', () => {
 
     const result = ResolveMigrations(discovered, applied, '1', false, false);
 
-    // Out-of-order migrations still appear as PENDING in status but are NOT
-    // added to the pending execution list
     expect(result.PendingMigrations).toHaveLength(0);
     const status = result.StatusReport.find((s) => s.Version === '202401010000');
+    expect(status?.State).toBe('IGNORED');
+  });
+
+  it('includes out-of-order migration as PENDING when outOfOrder is true', () => {
+    const discovered = [
+      makeMigration({ Version: '202401010000', Description: 'Old migration' }),
+    ];
+    const applied = [
+      makeHistory({ Version: '202601010000', Description: 'Applied later' }),
+    ];
+
+    const result = ResolveMigrations(discovered, applied, '1', false, true);
+
+    expect(result.PendingMigrations).toHaveLength(1);
+    expect(result.PendingMigrations[0].Version).toBe('202401010000');
+    const status = result.StatusReport.find((s) => s.Version === '202401010000');
     expect(status?.State).toBe('PENDING');
+  });
+
+  it('marks all out-of-order migrations as IGNORED and keeps future ones PENDING', () => {
+    const discovered = [
+      makeMigration({ Version: '202301010000', Description: 'Very old' }),
+      makeMigration({ Version: '202401010000', Description: 'Old' }),
+      makeMigration({ Version: '202701010000', Description: 'Future' }),
+    ];
+    const applied = [
+      makeHistory({ Version: '202601010000', Description: 'Applied' }),
+    ];
+
+    const result = ResolveMigrations(discovered, applied, '1', false, false);
+
+    // Two migrations are below highest applied (202601010000)
+    const ignored = result.StatusReport.filter((s) => s.State === 'IGNORED');
+    expect(ignored).toHaveLength(2);
+    expect(ignored.map((s) => s.Version)).toEqual(['202301010000', '202401010000']);
+
+    // One migration is above — should be PENDING
+    const pending = result.StatusReport.filter((s) => s.State === 'PENDING');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].Version).toBe('202701010000');
+
+    // Only the future migration should be in PendingMigrations
+    expect(result.PendingMigrations).toHaveLength(1);
+    expect(result.PendingMigrations[0].Version).toBe('202701010000');
   });
 });

--- a/packages/core/src/core/skyway.ts
+++ b/packages/core/src/core/skyway.ts
@@ -235,6 +235,30 @@ export class Skyway {
         );
       }
 
+      // Check for out-of-order migrations when outOfOrder is disabled
+      const ignoredMigrations = resolution.StatusReport.filter(
+        (s) => s.State === 'IGNORED'
+      );
+
+      if (ignoredMigrations.length > 0) {
+        for (const m of ignoredMigrations) {
+          this.callbacks.OnLog?.(
+            `WARNING: Out-of-order migration detected: ${m.Version} (${m.Description})`
+          );
+        }
+        const versions = ignoredMigrations.map((m) => m.Version).join(', ');
+        return {
+          MigrationsApplied: 0,
+          TotalExecutionTimeMS: Date.now() - startTime,
+          CurrentVersion: this.getCurrentVersion(currentHistory),
+          Details: [],
+          Success: false,
+          ErrorMessage:
+            `Detected resolved migration not applied to database: ${versions}. ` +
+            `To allow out-of-order migrations, set outOfOrder to true.`,
+        };
+      }
+
       if (resolution.PendingMigrations.length === 0) {
         this.callbacks.OnLog?.('Schema is up to date. No migrations to apply.');
         return {
@@ -379,6 +403,24 @@ export class Skyway {
         errors.push(
           `Checksum mismatch for version ${record.Version} (${record.Description}): ` +
             `expected ${record.Checksum} but computed ${diskMigration.Checksum}`
+        );
+      }
+    }
+
+    // Check for out-of-order migrations
+    const resolution = ResolveMigrations(
+      discovered,
+      applied,
+      this.config.Migrations.BaselineVersion,
+      this.config.Migrations.BaselineOnMigrate,
+      this.config.Migrations.OutOfOrder
+    );
+
+    for (const status of resolution.StatusReport) {
+      if (status.State === 'IGNORED') {
+        errors.push(
+          `Detected resolved migration not applied to database: ${status.Version}. ` +
+          `To allow out-of-order migrations, set outOfOrder to true.`
         );
       }
     }

--- a/packages/core/src/migration/resolver.ts
+++ b/packages/core/src/migration/resolver.ts
@@ -161,12 +161,12 @@ export function ResolveMigrations(
       highestApplied !== null &&
       migration.Version! < highestApplied
     ) {
-      // Out of order and not allowed — skip but warn
+      // Out of order and not allowed — mark as ignored
       statusReport.push({
         Type: 'versioned',
         Version: migration.Version,
         Description: migration.Description,
-        State: 'PENDING',
+        State: 'IGNORED',
         Script: migration.ScriptPath,
         DiskChecksum: migration.Checksum,
         AppliedChecksum: null,

--- a/packages/core/src/migration/types.ts
+++ b/packages/core/src/migration/types.ts
@@ -68,7 +68,8 @@ export type MigrationState =
   | 'FAILED'           // Recorded as failed in history table
   | 'OUTDATED'         // Repeatable migration with changed checksum
   | 'BASELINE'         // Applied as a baseline migration
-  | 'ABOVE_BASELINE';  // Version is above baseline, skipped
+  | 'ABOVE_BASELINE'   // Version is above baseline, skipped
+  | 'IGNORED';         // Out-of-order migration skipped (outOfOrder=false)
 
 /**
  * Combined view of a migration's disk info and database state.


### PR DESCRIPTION
When outOfOrder=false (the default) and an unapplied migration has a version lower than the highest applied version, Skyway now fails with a clear error message instead of silently excluding it. This matches Flyway's validation behavior and prevents undetected schema divergence.

- Add IGNORED state to MigrationState for out-of-order migrations
- Migrate() returns Success=false with actionable error message
- Validate() reports out-of-order migrations as validation errors
- CLI info table shows IGNORED migrations in red

Fix for #9 