### PR TITLE
Add detailed error context and batch progress reporting

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3793,10 +3793,10 @@
     },
     "packages/cli": {
       "name": "@memberjunction/skyway-cli",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
-        "@memberjunction/skyway-core": "^0.5.2",
+        "@memberjunction/skyway-core": "^0.5.3",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5"
@@ -3823,7 +3823,7 @@
     },
     "packages/core": {
       "name": "@memberjunction/skyway-core",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.2",

--- a/packages/cli/src/bin/skyway.ts
+++ b/packages/cli/src/bin/skyway.ts
@@ -48,7 +48,8 @@ function addSharedOptions(cmd: Command): Command {
     .option('--config <path>', 'Path to config file')
     .option('--placeholder <key=value>', 'Set a placeholder (repeatable)', collect, [])
     .option('--dry-run', 'Show pending migrations without executing them')
-    .option('-q, --quiet', 'Suppress per-migration output, show summary only');
+    .option('-q, --quiet', 'Suppress per-migration output, show summary only')
+    .option('-v, --verbose', 'Enable verbose output with per-batch progress and detailed error context');
 }
 
 // ─── Commands ───────────────────────────────────────────────────────
@@ -60,7 +61,7 @@ addSharedOptions(
 ).action(async (opts) => {
   PrintBanner();
   const config = LoadConfig(mapOptions(opts));
-  const success = await RunMigrate(config, opts.quiet ?? false);
+  const success = await RunMigrate(config, opts.quiet ?? false, opts.verbose ?? false);
   process.exit(success ? 0 : 1);
 });
 
@@ -183,6 +184,7 @@ function mapOptions(opts: Record<string, unknown>): CLIOptions {
     Config: opts.config as string | undefined,
     Placeholders: opts.placeholder as string[] | undefined,
     DryRun: opts.dryRun as boolean | undefined,
+    Verbose: opts.verbose as boolean | undefined,
   };
 }
 

--- a/packages/cli/src/commands/migrate.ts
+++ b/packages/cli/src/commands/migrate.ts
@@ -5,21 +5,23 @@
 
 import { Skyway } from '@memberjunction/skyway-core';
 import { SkywayConfig } from '@memberjunction/skyway-core';
-import { LogMigrationStart, LogMigrationEnd, LogInfo, LogError, PrintMigrateSummary } from '../formatting';
+import { LogMigrationStart, LogMigrationEnd, LogInfo, LogError, LogBatchProgress, PrintMigrateSummary } from '../formatting';
 
 /**
  * Executes the migrate command: applies all pending migrations.
  *
  * @param config - Resolved Skyway configuration
  * @param quiet - When true, suppress per-migration output
+ * @param verbose - When true, enable per-batch progress logging
  */
-export async function RunMigrate(config: SkywayConfig, quiet: boolean = false): Promise<boolean> {
+export async function RunMigrate(config: SkywayConfig, quiet: boolean = false, verbose: boolean = false): Promise<boolean> {
   const skyway = new Skyway(config);
 
   if (!quiet) {
     skyway.OnProgress({
       OnMigrationStart: LogMigrationStart,
       OnMigrationEnd: LogMigrationEnd,
+      OnBatchEnd: verbose ? LogBatchProgress : undefined,
       OnLog: LogInfo,
     });
   } else {
@@ -33,6 +35,9 @@ export async function RunMigrate(config: SkywayConfig, quiet: boolean = false): 
     LogInfo(`Schema: ${config.Migrations.DefaultSchema ?? 'dbo'}`);
     LogInfo(`Locations: ${config.Migrations.Locations.join(', ')}`);
     LogInfo(`Transaction mode: ${config.TransactionMode ?? 'per-run'}`);
+    if (config.Verbose || verbose) {
+      LogInfo('Verbose: enabled');
+    }
     if (config.DryRun) {
       LogInfo('Mode: DRY RUN');
     }
@@ -45,7 +50,8 @@ export async function RunMigrate(config: SkywayConfig, quiet: boolean = false): 
       result.TotalExecutionTimeMS,
       result.CurrentVersion,
       result.Success,
-      result.ErrorMessage
+      result.ErrorMessage,
+      config.TransactionMode ?? 'per-run'
     );
 
     return result.Success;

--- a/packages/cli/src/config-loader.ts
+++ b/packages/cli/src/config-loader.ts
@@ -72,6 +72,9 @@ export interface CLIOptions {
 
   /** Dry-run mode */
   DryRun?: boolean;
+
+  /** Verbose output mode */
+  Verbose?: boolean;
 }
 
 /**
@@ -181,6 +184,7 @@ export function LoadConfig(cliOptions: CLIOptions, cwd: string = process.cwd()):
       ?? fileConfig?.TransactionMode
       ?? 'per-run',
     DryRun: cliOptions.DryRun ?? fileConfig?.DryRun ?? false,
+    Verbose: cliOptions.Verbose ?? fileConfig?.Verbose ?? false,
   };
 }
 
@@ -251,6 +255,7 @@ const KEY_MAP: Record<string, string> = {
   placeholders: 'Placeholders',
   transactionMode: 'TransactionMode',
   dryRun: 'DryRun',
+  verbose: 'Verbose',
 };
 
 /**

--- a/packages/cli/src/formatting.ts
+++ b/packages/cli/src/formatting.ts
@@ -5,7 +5,7 @@
  */
 
 import chalk from 'chalk';
-import { MigrationStatus, MigrationState, ResolvedMigration, MigrationExecutionResult } from '@memberjunction/skyway-core';
+import { MigrationStatus, MigrationState, ResolvedMigration, MigrationExecutionResult, MigrationExecutionError, TruncateSQL } from '@memberjunction/skyway-core';
 
 /**
  * Prints the Skyway banner to the console.
@@ -65,7 +65,7 @@ export function LogMigrationStart(migration: ResolvedMigration): void {
 }
 
 /**
- * Logs a migration execution result.
+ * Logs a migration execution result with detailed batch and context info on failure.
  */
 export function LogMigrationEnd(result: MigrationExecutionResult): void {
   if (result.Success) {
@@ -73,9 +73,46 @@ export function LogMigrationEnd(result: MigrationExecutionResult): void {
   } else {
     console.log(chalk.red(` FAILED`));
     if (result.Error) {
-      console.log(chalk.red(`    ${result.Error.message}`));
+      const err = result.Error;
+      if (err instanceof MigrationExecutionError && err.BatchInfo) {
+        const info = err.BatchInfo;
+        console.log(chalk.red(`\n    Migration failed: ${err.Script}`));
+        console.log(chalk.red(`    Batch ${info.BatchNumber} of ${info.TotalBatches} failed`));
+        console.log(chalk.red(`    File lines: ${info.StartLine}-${info.EndLine}`));
+        console.log(chalk.gray(`    ${info.SucceededBatches} batch(es) succeeded before failure`));
+
+        // Show the original SQL Server error
+        const cause = err.cause;
+        if (cause instanceof Error) {
+          console.log(chalk.red(`\n    SQL Error: ${cause.message}`));
+        }
+
+        // Show context lines that reference identifiers from the error
+        if (info.ContextLines && info.ContextLines.length > 0) {
+          console.log(chalk.yellow(`\n    Related lines in failed batch:`));
+          for (const ctx of info.ContextLines) {
+            console.log(chalk.yellow(`      Line ${ctx.LineNumber}: `) + chalk.white(ctx.Text));
+          }
+        }
+
+        // Show truncated batch SQL
+        console.log(chalk.gray(`\n    Failed batch SQL (first 500 chars):`));
+        const truncated = TruncateSQL(info.BatchSQL, 500);
+        for (const line of truncated.split('\n')) {
+          console.log(chalk.gray(`      ${line}`));
+        }
+      } else {
+        console.log(chalk.red(`    ${err.message}`));
+      }
     }
   }
+}
+
+/**
+ * Logs verbose batch progress.
+ */
+export function LogBatchProgress(batchIndex: number, totalBatches: number): void {
+  console.log(chalk.gray(`    Batch ${batchIndex}/${totalBatches} completed`));
 }
 
 /**
@@ -107,7 +144,8 @@ export function PrintMigrateSummary(
   totalMs: number,
   currentVersion: string | null,
   success: boolean,
-  errorMessage?: string
+  errorMessage?: string,
+  transactionMode?: string
 ): void {
   console.log();
   console.log(chalk.gray('  ' + '─'.repeat(50)));
@@ -127,6 +165,17 @@ export function PrintMigrateSummary(
     );
     if (errorMessage) {
       console.log(chalk.red(`  ${errorMessage}`));
+    }
+
+    // Transaction safety reporting
+    if (transactionMode === 'per-run') {
+      console.log(chalk.yellow(`  Transaction mode: per-run — all changes have been rolled back`));
+    } else if (transactionMode === 'per-migration') {
+      if (applied > 0) {
+        console.log(chalk.yellow(`  Transaction mode: per-migration — ${applied} prior migration(s) remain committed, failed migration was rolled back`));
+      } else {
+        console.log(chalk.yellow(`  Transaction mode: per-migration — failed migration was rolled back`));
+      }
     }
   }
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -13,7 +13,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/packages/core/src/__tests__/error-context.test.ts
+++ b/packages/core/src/__tests__/error-context.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { ExtractErrorIdentifiers, FindContextLines, TruncateSQL } from '../executor/error-context';
+
+describe('ExtractErrorIdentifiers', () => {
+  it('extracts column name from Invalid column name error', () => {
+    const ids = ExtractErrorIdentifiers("Invalid column name '__mj_CreatedAt'");
+    expect(ids).toContain('__mj_CreatedAt');
+  });
+
+  it('extracts object name from Invalid object name error', () => {
+    const ids = ExtractErrorIdentifiers("Invalid object name 'dbo.MyTable'");
+    expect(ids).toContain('dbo.MyTable');
+  });
+
+  it('extracts multiple identifiers from a single message', () => {
+    const ids = ExtractErrorIdentifiers(
+      "Invalid column name 'Foo' in table \"Bar\""
+    );
+    expect(ids).toContain('Foo');
+    expect(ids).toContain('Bar');
+  });
+
+  it('returns empty array for unrecognized error messages', () => {
+    const ids = ExtractErrorIdentifiers('Timeout expired');
+    expect(ids).toEqual([]);
+  });
+
+  it('handles stored procedure errors', () => {
+    const ids = ExtractErrorIdentifiers("Could not find stored procedure 'sp_DoSomething'");
+    expect(ids).toContain('sp_DoSomething');
+  });
+
+  it('handles already-exists errors', () => {
+    const ids = ExtractErrorIdentifiers("There is already an object named 'MyTable' in the database");
+    expect(ids).toContain('MyTable');
+  });
+});
+
+describe('FindContextLines', () => {
+  it('finds lines referencing an identifier', () => {
+    const batchSQL = [
+      'ALTER TABLE Employees',
+      'ADD __mj_CreatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE();',
+      'ALTER TABLE Employees',
+      'ADD __mj_UpdatedAt DATETIME2 NOT NULL DEFAULT GETUTCDATE();',
+    ].join('\n');
+
+    const lines = FindContextLines(batchSQL, 100, ['__mj_CreatedAt']);
+    expect(lines).toHaveLength(1);
+    expect(lines[0].LineNumber).toBe(101); // 100 + 1 (second line, 0-indexed)
+    expect(lines[0].Text).toContain('__mj_CreatedAt');
+  });
+
+  it('finds multiple lines for the same identifier', () => {
+    const batchSQL = [
+      'SELECT __mj_CreatedAt FROM Foo;',
+      'UPDATE Foo SET __mj_CreatedAt = GETDATE();',
+    ].join('\n');
+
+    const lines = FindContextLines(batchSQL, 1, ['__mj_CreatedAt']);
+    expect(lines).toHaveLength(2);
+    expect(lines[0].LineNumber).toBe(1);
+    expect(lines[1].LineNumber).toBe(2);
+  });
+
+  it('returns empty array when no identifiers provided', () => {
+    const lines = FindContextLines('SELECT 1;', 1, []);
+    expect(lines).toEqual([]);
+  });
+
+  it('returns empty array when no matches found', () => {
+    const lines = FindContextLines('SELECT 1;', 1, ['NoSuchThing']);
+    expect(lines).toEqual([]);
+  });
+
+  it('does not add the same line twice for multiple identifier matches', () => {
+    const batchSQL = 'ALTER TABLE Foo ADD Bar INT, Baz INT;';
+    const lines = FindContextLines(batchSQL, 1, ['Bar', 'Baz']);
+    expect(lines).toHaveLength(1);
+  });
+});
+
+describe('TruncateSQL', () => {
+  it('returns short SQL unchanged', () => {
+    expect(TruncateSQL('SELECT 1;', 500)).toBe('SELECT 1;');
+  });
+
+  it('truncates long SQL with ellipsis', () => {
+    const longSQL = 'A'.repeat(600);
+    const result = TruncateSQL(longSQL, 500);
+    expect(result.length).toBeLessThan(600);
+    expect(result).toContain('... (truncated)');
+  });
+
+  it('uses default maxLength of 500', () => {
+    const longSQL = 'B'.repeat(600);
+    const result = TruncateSQL(longSQL);
+    expect(result).toContain('... (truncated)');
+    expect(result.startsWith('B'.repeat(500))).toBe(true);
+  });
+});

--- a/packages/core/src/__tests__/sql-splitter.test.ts
+++ b/packages/core/src/__tests__/sql-splitter.test.ts
@@ -72,6 +72,21 @@ describe('SplitOnGO', () => {
     expect(batches[1].StartLine).toBe(3);
   });
 
+  it('tracks correct EndLine for each batch', () => {
+    const script = 'SELECT 1;\nGO\nSELECT 2;\nSELECT 3;\nGO';
+    const batches = SplitOnGO(script);
+    // Batch 1: line 1 (SELECT 1;), GO is on line 2
+    expect(batches[0].EndLine).toBe(1);
+    // Batch 2: lines 3-4 (SELECT 2; SELECT 3;), GO is on line 5
+    expect(batches[1].EndLine).toBe(4);
+  });
+
+  it('tracks EndLine for final batch without trailing GO', () => {
+    const script = 'SELECT 1;\nGO\nSELECT 2;\nSELECT 3;';
+    const batches = SplitOnGO(script);
+    expect(batches[1].EndLine).toBe(4); // total lines = 4
+  });
+
   it('handles empty input', () => {
     const batches = SplitOnGO('');
     expect(batches).toHaveLength(0);

--- a/packages/core/src/core/config.ts
+++ b/packages/core/src/core/config.ts
@@ -56,6 +56,13 @@ export interface SkywayConfig {
    * Defaults to false.
    */
   DryRun?: boolean;
+
+  /**
+   * When true, enables verbose output including per-batch progress logging
+   * and detailed SQL context on errors.
+   * Defaults to false.
+   */
+  Verbose?: boolean;
 }
 
 /**
@@ -130,5 +137,6 @@ export function resolveConfig(config: SkywayConfig): Required<SkywayConfig> & { 
     Placeholders: config.Placeholders ?? {},
     TransactionMode: config.TransactionMode ?? 'per-run',
     DryRun: config.DryRun ?? false,
+    Verbose: config.Verbose ?? false,
   };
 }

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -22,6 +22,32 @@ export class SkywayError extends Error {
 }
 
 /**
+ * Details about the failed SQL batch for enhanced error reporting.
+ */
+export interface FailedBatchInfo {
+  /** 1-based index of the failed batch */
+  BatchNumber: number;
+
+  /** Total number of batches in the migration */
+  TotalBatches: number;
+
+  /** 1-based line number where the batch starts in the original file */
+  StartLine: number;
+
+  /** 1-based line number where the batch ends in the original file */
+  EndLine: number;
+
+  /** Number of batches that succeeded before this one */
+  SucceededBatches: number;
+
+  /** The full SQL of the failed batch */
+  BatchSQL: string;
+
+  /** Lines from the batch that reference identifiers mentioned in the error */
+  ContextLines?: { LineNumber: number; Text: string }[];
+}
+
+/**
  * Thrown when a migration file fails to execute against SQL Server.
  * Contains details about which migration failed and the SQL error.
  */
@@ -32,21 +58,26 @@ export class MigrationExecutionError extends SkywayError {
   /** The migration script filename */
   readonly Script: string;
 
-  /** The specific SQL batch that failed, if identifiable */
+  /** The specific SQL batch that failed, if identifiable (first 500 chars) */
   readonly FailedSQL?: string;
+
+  /** Detailed information about the failed batch */
+  readonly BatchInfo?: FailedBatchInfo;
 
   constructor(
     version: string | null,
     script: string,
     message: string,
     failedSQL?: string,
-    cause?: Error
+    cause?: Error,
+    batchInfo?: FailedBatchInfo
   ) {
     super('MIGRATION_EXECUTION_FAILED', message, cause);
     this.name = 'MigrationExecutionError';
     this.Version = version;
     this.Script = script;
     this.FailedSQL = failedSQL;
+    this.BatchInfo = batchInfo;
   }
 }
 

--- a/packages/core/src/core/skyway.ts
+++ b/packages/core/src/core/skyway.ts
@@ -129,6 +129,9 @@ export interface SkywayCallbacks {
   /** Called when a migration finishes (success or failure) */
   OnMigrationEnd?: (result: MigrationExecutionResult) => void;
 
+  /** Called after each SQL batch completes successfully (verbose mode) */
+  OnBatchEnd?: (batchIndex: number, totalBatches: number) => void;
+
   /** Called for informational log messages */
   OnLog?: (message: string) => void;
 }
@@ -939,6 +942,8 @@ export class Skyway {
     const { SubstitutePlaceholders } = await import('../executor/placeholder');
     const { SplitOnGO } = await import('../executor/sql-splitter');
     const { ComputeChecksum } = await import('../migration/checksum');
+    const { ExtractErrorIdentifiers, FindContextLines } = await import('../executor/error-context');
+    const { MigrationExecutionError } = await import('./errors');
 
     const startTime = Date.now();
 
@@ -973,9 +978,46 @@ export class Skyway {
       for (let i = 0; i < batches.length; i++) {
         const batch = batches[i];
         for (let repeat = 0; repeat < batch.RepeatCount; repeat++) {
-          const request = new sql.Request(transaction);
-          await request.batch(batch.SQL);
+          try {
+            const request = new sql.Request(transaction);
+            await request.batch(batch.SQL);
+          } catch (batchErr) {
+            const elapsedMS = Date.now() - startTime;
+            const errorMessage = batchErr instanceof Error ? batchErr.message : String(batchErr);
+
+            // Extract identifiers from error and find related lines
+            const identifiers = ExtractErrorIdentifiers(errorMessage);
+            const contextLines = FindContextLines(batch.SQL, batch.StartLine, identifiers);
+
+            const batchInfo = {
+              BatchNumber: i + 1,
+              TotalBatches: batches.length,
+              StartLine: batch.StartLine,
+              EndLine: batch.EndLine,
+              SucceededBatches: i,
+              BatchSQL: batch.SQL,
+              ContextLines: contextLines.length > 0 ? contextLines : undefined,
+            };
+
+            const error = new MigrationExecutionError(
+              migration.Version,
+              migration.ScriptPath,
+              `Failed at batch ${i + 1}/${batches.length} (lines ${batch.StartLine}-${batch.EndLine}): ${errorMessage}`,
+              batch.SQL.substring(0, 500),
+              batchErr instanceof Error ? batchErr : undefined,
+              batchInfo
+            );
+
+            return {
+              Migration: migration,
+              Success: false,
+              ExecutionTimeMS: elapsedMS,
+              Error: error,
+            };
+          }
         }
+
+        this.callbacks.OnBatchEnd?.(i + 1, batches.length);
       }
 
       return {

--- a/packages/core/src/executor/error-context.ts
+++ b/packages/core/src/executor/error-context.ts
@@ -1,0 +1,110 @@
+/**
+ * @module executor/error-context
+ * Extracts contextual information from SQL errors to help debug failed migrations.
+ *
+ * When a SQL batch fails, the error message often references identifiers like
+ * column names, table names, or constraint names. This module extracts those
+ * identifiers and finds the lines in the batch SQL that reference them,
+ * providing file-level line numbers for easy navigation in an editor.
+ */
+
+/**
+ * A line from the failed batch that relates to the error.
+ */
+export interface ContextLine {
+  /** 1-based line number in the original migration file */
+  LineNumber: number;
+  /** The text content of the line */
+  Text: string;
+}
+
+/**
+ * Common SQL Server error message patterns that contain identifiers.
+ * Each pattern captures the identifier name in group 1.
+ */
+const IDENTIFIER_PATTERNS: RegExp[] = [
+  /Invalid column name '([^']+)'/i,
+  /Invalid object name '([^']+)'/i,
+  /Column name '([^']+)'/i,
+  /Could not find stored procedure '([^']+)'/i,
+  /There is already an object named '([^']+)'/i,
+  /Cannot find the object "([^"]+)"/i,
+  /constraint "([^"]+)"/i,
+  /constraint '([^']+)'/i,
+  /index '([^']+)'/i,
+  /Cannot insert duplicate key.*object '([^']+)'/i,
+  /FOREIGN KEY constraint "([^"]+)"/i,
+  /FOREIGN KEY constraint '([^']+)'/i,
+  /table "([^"]+)"/i,
+  /column "([^"]+)"/i,
+];
+
+/**
+ * Extracts identifiers mentioned in a SQL Server error message.
+ *
+ * @param errorMessage - The error message from SQL Server
+ * @returns Array of unique identifiers found in the error message
+ */
+export function ExtractErrorIdentifiers(errorMessage: string): string[] {
+  const identifiers = new Set<string>();
+
+  for (const pattern of IDENTIFIER_PATTERNS) {
+    const match = errorMessage.match(pattern);
+    if (match?.[1]) {
+      identifiers.add(match[1]);
+    }
+  }
+
+  return Array.from(identifiers);
+}
+
+/**
+ * Finds lines in a SQL batch that reference the given identifiers.
+ * Returns lines with their original file line numbers.
+ *
+ * @param batchSQL - The SQL text of the failed batch
+ * @param batchStartLine - 1-based line number where the batch starts in the file
+ * @param identifiers - Identifiers to search for (column names, table names, etc.)
+ * @returns Array of context lines referencing the identifiers
+ */
+export function FindContextLines(
+  batchSQL: string,
+  batchStartLine: number,
+  identifiers: string[]
+): ContextLine[] {
+  if (identifiers.length === 0) {
+    return [];
+  }
+
+  const lines = batchSQL.split('\n');
+  const contextLines: ContextLine[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    for (const identifier of identifiers) {
+      if (line.includes(identifier)) {
+        contextLines.push({
+          LineNumber: batchStartLine + i,
+          Text: line.trimEnd(),
+        });
+        break; // Don't add the same line twice
+      }
+    }
+  }
+
+  return contextLines;
+}
+
+/**
+ * Truncates SQL text for display, adding an ellipsis if truncated.
+ *
+ * @param sql - SQL text to truncate
+ * @param maxLength - Maximum character length (default 500)
+ * @returns Truncated SQL string
+ */
+export function TruncateSQL(sql: string, maxLength: number = 500): string {
+  if (sql.length <= maxLength) {
+    return sql;
+  }
+  return sql.substring(0, maxLength) + '\n... (truncated)';
+}

--- a/packages/core/src/executor/executor.ts
+++ b/packages/core/src/executor/executor.ts
@@ -26,7 +26,8 @@ import * as sql from 'mssql';
 import { ResolvedMigration } from '../migration/types';
 import { SplitOnGO } from './sql-splitter';
 import { SubstitutePlaceholders, PlaceholderContext } from './placeholder';
-import { MigrationExecutionError, TransactionError } from '../core/errors';
+import { MigrationExecutionError, TransactionError, FailedBatchInfo } from '../core/errors';
+import { ExtractErrorIdentifiers, FindContextLines } from './error-context';
 
 /**
  * Result of executing a single migration file.
@@ -57,6 +58,9 @@ export interface ExecutionCallbacks {
 
   /** Called before each SQL batch within a migration */
   OnBatchStart?: (batchIndex: number, totalBatches: number) => void;
+
+  /** Called after each SQL batch completes successfully (verbose mode) */
+  OnBatchEnd?: (batchIndex: number, totalBatches: number) => void;
 
   /** Called for informational log messages */
   OnLog?: (message: string) => void;
@@ -286,14 +290,29 @@ async function executeSingleMigration(
           await request.batch(batch.SQL);
         } catch (batchErr) {
           const elapsedMS = Date.now() - startTime;
+          const errorMessage = batchErr instanceof Error ? batchErr.message : String(batchErr);
+
+          // Extract identifiers from error and find related lines
+          const identifiers = ExtractErrorIdentifiers(errorMessage);
+          const contextLines = FindContextLines(batch.SQL, batch.StartLine, identifiers);
+
+          const batchInfo: FailedBatchInfo = {
+            BatchNumber: i + 1,
+            TotalBatches: batches.length,
+            StartLine: batch.StartLine,
+            EndLine: batch.EndLine,
+            SucceededBatches: i,
+            BatchSQL: batch.SQL,
+            ContextLines: contextLines.length > 0 ? contextLines : undefined,
+          };
+
           const error = new MigrationExecutionError(
             migration.Version,
             migration.ScriptPath,
-            `Failed at batch ${i + 1}/${batches.length} (line ${batch.StartLine}): ${
-              batchErr instanceof Error ? batchErr.message : String(batchErr)
-            }`,
+            `Failed at batch ${i + 1}/${batches.length} (lines ${batch.StartLine}-${batch.EndLine}): ${errorMessage}`,
             batch.SQL.substring(0, 500),
-            batchErr instanceof Error ? batchErr : undefined
+            batchErr instanceof Error ? batchErr : undefined,
+            batchInfo
           );
 
           const result: MigrationExecutionResult = {
@@ -306,6 +325,8 @@ async function executeSingleMigration(
           return result;
         }
       }
+
+      callbacks?.OnBatchEnd?.(i + 1, batches.length);
     }
 
     // Step 4: Success

--- a/packages/core/src/executor/sql-splitter.ts
+++ b/packages/core/src/executor/sql-splitter.ts
@@ -29,6 +29,9 @@ export interface SQLBatch {
 
   /** 1-based line number where this batch starts in the original script */
   StartLine: number;
+
+  /** 1-based line number where this batch ends in the original script */
+  EndLine: number;
 }
 
 /**
@@ -91,6 +94,7 @@ export function SplitOnGO(script: string): SQLBatch[] {
           SQL: batchSQL,
           RepeatCount: repeatCount,
           StartLine: batchStartLine,
+          EndLine: i, // line before the GO (0-based i → 1-based is i, since GO is on line i+1)
         });
       }
 
@@ -109,6 +113,7 @@ export function SplitOnGO(script: string): SQLBatch[] {
       SQL: finalSQL,
       RepeatCount: 1,
       StartLine: batchStartLine,
+      EndLine: lines.length,
     });
   }
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -66,6 +66,7 @@ export { ResolveMigrations } from './migration/resolver';
 export { SplitOnGO, SQLBatch } from './executor/sql-splitter';
 export { SubstitutePlaceholders, PlaceholderContext } from './executor/placeholder';
 export { MigrationExecutionResult, ExecutionCallbacks } from './executor/executor';
+export { ExtractErrorIdentifiers, FindContextLines, TruncateSQL, ContextLine } from './executor/error-context';
 
 // ─── History ─────────────────────────────────────────────────────────
 export { HistoryTable } from './history/history-table';
@@ -79,4 +80,5 @@ export {
   ChecksumMismatchError,
   TransactionError,
   ConnectionError,
+  FailedBatchInfo,
 } from './core/errors';

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -13,7 +13,8 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "moduleResolution": "node"
+    "moduleResolution": "node",
+    "ignoreDeprecations": "5.0"
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
This PR enhances error reporting and adds verbose progress logging for SQL migrations. When a migration fails, the system now extracts identifiers from SQL Server error messages and displays the relevant lines from the failed batch, making it easier to debug issues. Additionally, a new verbose mode provides per-batch progress updates during migration execution.

## Key Changes

- **New error context module** (`error-context.ts`): Extracts identifiers (table names, column names, etc.) from SQL Server error messages and finds the corresponding lines in the failed SQL batch with their original file line numbers.

- **Enhanced error reporting**: `MigrationExecutionError` now includes `FailedBatchInfo` containing:
  - Batch number and total batch count
  - Start and end line numbers in the original file
  - Number of succeeded batches before failure
  - Context lines that reference identifiers mentioned in the error
  - Full SQL of the failed batch

- **Batch tracking improvements**: `SQLBatch` interface now includes `EndLine` to track where each batch ends in the original script, enabling precise error location reporting.

- **Verbose mode support**: 
  - New `Verbose` configuration option in `SkywayConfig`
  - New `OnBatchEnd` callback in `SkywayCallbacks` for per-batch progress logging
  - CLI `--verbose` flag to enable detailed output
  - `LogBatchProgress` function to display batch completion status

- **Improved CLI output**: `LogMigrationEnd` now displays:
  - Detailed batch information (number, line range)
  - Related lines from the failed batch
  - Truncated batch SQL for context
  - Transaction mode safety information

- **Configuration enhancements**: Added `Verbose` option to CLI options, config loader, and core configuration with proper defaults.

## Implementation Details

- Error identifier extraction uses regex patterns to match common SQL Server error formats (invalid column/object names, constraints, stored procedures, etc.)
- Context lines are found by searching the failed batch SQL for identifier matches, with file-level line numbers computed from batch start position
- SQL truncation utility prevents overwhelming output while preserving context
- Batch progress callbacks are optional and only invoked when verbose mode is enabled
- All changes maintain backward compatibility with existing error handling

https://claude.ai/code/session_01BUyn4MrL6Uzz4Si3GNgHpz