### PR TITLE
feat(history): configurable HistoryExtraColumns

### DIFF
--- a/.changeset/history-extra-columns.md
+++ b/.changeset/history-extra-columns.md
@@ -1,0 +1,6 @@
+---
+"@memberjunction/skyway-core": minor
+"@memberjunction/skyway-cli": minor
+---
+
+Add `HistoryExtraColumns` to `MigrationConfig`. A Skyway instance can now extend its history table with user-defined columns that either carry a per-row `Value` (bound as a SQL parameter on every insert) or fall through to a `DefaultValue`/NULL. This lets a secondary Skyway instance — for example, one running integration-specific DDL alongside core application migrations — stamp domain context (e.g. `CompanyIntegrationID`) onto every history row so each migration row links back to the context that triggered it. Default behavior is unchanged: core Flyway columns only.

--- a/.changeset/history-extra-columns.md
+++ b/.changeset/history-extra-columns.md
@@ -4,3 +4,7 @@
 ---
 
 Add `HistoryExtraColumns` to `MigrationConfig`. A Skyway instance can now extend its history table with user-defined columns that either carry a per-row `Value` (bound as a SQL parameter on every insert) or fall through to a `DefaultValue`/NULL. This lets a secondary Skyway instance — for example, one running integration-specific DDL alongside core application migrations — stamp domain context (e.g. `CompanyIntegrationID`) onto every history row so each migration row links back to the context that triggered it. Default behavior is unchanged: core Flyway columns only.
+
+`EnsureExists` reconciles extras onto an **existing** history table rather than only emitting them in the `CREATE TABLE` branch. Previously, enabling `HistoryExtraColumns` against a database Skyway had already migrated left the columns absent while every `Insert*` referenced them, so the run died with a bare `Invalid column name '<Col>'` and applied zero migrations — which is the primary intended use case (tagging migration rows on an existing application database). Missing columns are now added via `ALTER TABLE`; rows written before the column existed keep its `DefaultValue` or NULL.
+
+Two configuration mistakes now fail fast with an actionable message before any DDL runs, instead of surfacing as a raw SQL error mid-run: a `NOT NULL` extra with neither a `Value` nor a `DefaultValue` (every insert would fail), and retrofitting a `NOT NULL` extra without a `DefaultValue` onto a history table that already has rows (SQL Server rejects the `ALTER`).

--- a/package-lock.json
+++ b/package-lock.json
@@ -3472,6 +3472,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3552,6 +3553,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -3645,6 +3647,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3793,10 +3796,10 @@
     },
     "packages/cli": {
       "name": "@memberjunction/skyway-cli",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
-        "@memberjunction/skyway-core": "^0.5.2",
+        "@memberjunction/skyway-core": "^0.5.3",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5"
@@ -3823,7 +3826,7 @@
     },
     "packages/core": {
       "name": "@memberjunction/skyway-core",
-      "version": "0.5.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.2",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -86,6 +86,42 @@ const skyway = new Skyway({
 });
 ```
 
+### Custom history columns
+
+The default history table carries the ten Flyway-compatible columns. When one database needs to track migrations across multiple logical contexts — for example, core application migrations alongside per-tenant or per-integration migrations — use a **second Skyway instance** with its own `HistoryTable` name. Both instances can share a schema without stepping on each other.
+
+Each non-default instance can also declare extra columns that carry domain context on every history row. Skyway creates the columns during `EnsureExists` and, when `Value` is supplied, stamps it (via parameter binding) onto every insert:
+
+```typescript
+const integrationSkyway = new Skyway({
+  Database: { /* ... */ },
+  Migrations: {
+    Locations: ['./integration-migrations'],
+    DefaultSchema: '__mj',
+    HistoryTable: 'IntegrationSchemaHistory',
+    HistoryExtraColumns: [
+      {
+        Name: 'CompanyIntegrationID',
+        SqlType: 'UNIQUEIDENTIFIER',
+        IsNullable: false,
+        Value: companyIntegrationId,   // stamped on every row in this run
+      },
+      {
+        Name: 'Notes',
+        SqlType: 'NVARCHAR(400)',
+        DefaultValue: "N''",           // no Value — falls through to DEFAULT
+      },
+    ],
+  },
+});
+```
+
+Rules:
+- Extras are **appended** to the Flyway columns; the core ten are never replaced.
+- Extras without a `Value` must be nullable or carry a `DefaultValue`.
+- `Value` is always bound as a SQL parameter — safe against injection regardless of source.
+- Changes to `HistoryExtraColumns` only take effect on a table Skyway creates. Pre-existing history tables are not altered; either drop the table or add the columns manually.
+
 ### Progress Callbacks
 
 ```typescript

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -118,9 +118,16 @@ const integrationSkyway = new Skyway({
 
 Rules:
 - Extras are **appended** to the Flyway columns; the core ten are never replaced.
-- Extras without a `Value` must be nullable or carry a `DefaultValue`.
+- Extras without a `Value` must be nullable or carry a `DefaultValue`. Skyway checks this
+  before touching the database and fails with a message naming the offending column.
 - `Value` is always bound as a SQL parameter — safe against injection regardless of source.
-- Changes to `HistoryExtraColumns` only take effect on a table Skyway creates. Pre-existing history tables are not altered; either drop the table or add the columns manually.
+- Extras are reconciled onto an **existing** history table too: `EnsureExists` adds any
+  configured column that is missing, so you can turn `HistoryExtraColumns` on for a database
+  Skyway has already migrated. Rows written before the column existed keep its `DefaultValue`
+  (or NULL); rows written after are stamped.
+- SQL Server cannot add a `NOT NULL` column to a table that already has rows. Retrofitting a
+  `NOT NULL` extra onto a populated history table therefore requires a `DefaultValue`; without
+  one, Skyway fails with an actionable message instead of a bare engine error.
 
 ### Progress Callbacks
 

--- a/packages/core/src/__tests__/config.test.ts
+++ b/packages/core/src/__tests__/config.test.ts
@@ -49,6 +49,47 @@ describe('resolveConfig', () => {
     expect(resolved.Placeholders).toEqual({});
   });
 
+  it('applies default empty HistoryExtraColumns', () => {
+    const resolved = resolveConfig(minimalConfig);
+    expect(resolved.Migrations.HistoryExtraColumns).toEqual([]);
+  });
+
+  it('preserves HistoryExtraColumns with values and defaults', () => {
+    const config: SkywayConfig = {
+      ...minimalConfig,
+      Migrations: {
+        ...minimalConfig.Migrations,
+        HistoryTable: 'IntegrationSchemaHistory',
+        HistoryExtraColumns: [
+          {
+            Name: 'CompanyIntegrationID',
+            SqlType: 'UNIQUEIDENTIFIER',
+            IsNullable: false,
+            Value: 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890',
+          },
+          {
+            Name: 'TriggeredBy',
+            SqlType: 'NVARCHAR(200)',
+            DefaultValue: "N'system'",
+          },
+        ],
+      },
+    };
+    const resolved = resolveConfig(config);
+    expect(resolved.Migrations.HistoryTable).toBe('IntegrationSchemaHistory');
+    expect(resolved.Migrations.HistoryExtraColumns).toHaveLength(2);
+    expect(resolved.Migrations.HistoryExtraColumns[0]).toMatchObject({
+      Name: 'CompanyIntegrationID',
+      SqlType: 'UNIQUEIDENTIFIER',
+      IsNullable: false,
+      Value: 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890',
+    });
+    expect(resolved.Migrations.HistoryExtraColumns[1]).toMatchObject({
+      Name: 'TriggeredBy',
+      DefaultValue: "N'system'",
+    });
+  });
+
   it('preserves user-specified values', () => {
     const config: SkywayConfig = {
       ...minimalConfig,

--- a/packages/core/src/__tests__/history-extra-columns.test.ts
+++ b/packages/core/src/__tests__/history-extra-columns.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import * as sql from 'mssql';
+import { HistoryTable } from '../history/history-table';
+import { HistoryExtraColumn } from '../history/types';
+
+/**
+ * A disconnected pool. The stampable-contract check runs before any DDL, so a
+ * config that passes validation fails later with a driver error instead — which
+ * is how these tests distinguish "rejected by the contract" from "got past it".
+ */
+function tableWith(extras: HistoryExtraColumn[]): HistoryTable {
+  return new HistoryTable({} as unknown as sql.ConnectionPool, 'dbo', 'flyway_schema_history', extras);
+}
+
+const CONTRACT_ERROR = /HistoryExtraColumns:/;
+
+/** Asserts EnsureExists got past validation (failing only on the dead pool). */
+async function expectPassesValidation(table: HistoryTable): Promise<void> {
+  await expect(table.EnsureExists()).rejects.toThrow();
+  await expect(table.EnsureExists()).rejects.not.toThrow(CONTRACT_ERROR);
+}
+
+describe('HistoryTable extra columns', () => {
+  describe('stampable contract', () => {
+    it('rejects a NOT NULL extra with no Value and no DefaultValue', async () => {
+      const table = tableWith([{ Name: 'CompanyIntegrationID', SqlType: 'UNIQUEIDENTIFIER', IsNullable: false }]);
+
+      await expect(table.EnsureExists()).rejects.toThrow(/CompanyIntegrationID.*NOT NULL.*no Value/s);
+    });
+
+    it('names the offending column so the operator can fix it', async () => {
+      const table = tableWith([
+        { Name: 'Ok', SqlType: 'NVARCHAR(50)', IsNullable: true },
+        { Name: 'Broken', SqlType: 'INT', IsNullable: false },
+      ]);
+
+      await expect(table.EnsureExists()).rejects.toThrow(/'Broken'/);
+    });
+
+    it('accepts a NOT NULL extra that carries a Value', async () => {
+      const table = tableWith([
+        { Name: 'CompanyIntegrationID', SqlType: 'UNIQUEIDENTIFIER', IsNullable: false, Value: 'abc' },
+      ]);
+
+      await expectPassesValidation(table);
+    });
+
+    it('accepts a NOT NULL extra that carries a DefaultValue', async () => {
+      const table = tableWith([
+        { Name: 'Tag', SqlType: 'NVARCHAR(50)', IsNullable: false, DefaultValue: "'unknown'" },
+      ]);
+
+      await expectPassesValidation(table);
+    });
+
+    it('accepts a nullable extra with no Value', async () => {
+      const table = tableWith([{ Name: 'AffectedTables', SqlType: 'NVARCHAR(MAX)', IsNullable: true }]);
+
+      await expectPassesValidation(table);
+    });
+
+    it('treats an omitted IsNullable as nullable', async () => {
+      const table = tableWith([{ Name: 'AffectedTables', SqlType: 'NVARCHAR(MAX)' }]);
+
+      await expectPassesValidation(table);
+    });
+  });
+});

--- a/packages/core/src/core/config.ts
+++ b/packages/core/src/core/config.ts
@@ -4,6 +4,9 @@
  */
 
 import { DatabaseConfig } from '../db/types';
+import { HistoryExtraColumn } from '../history/types';
+
+export type { HistoryExtraColumn };
 
 /**
  * Controls how transactions are applied during a migration run.
@@ -86,6 +89,23 @@ export interface MigrationConfig {
   HistoryTable?: string;
 
   /**
+   * Additional columns to add to the history table beyond the standard Flyway
+   * set. Skyway creates these columns during `EnsureExists` and, when each
+   * column's `Value` is supplied, writes it on every history-row insert
+   * during the run.
+   *
+   * Use this to make the history table carry domain context — for example,
+   * a `CompanyIntegrationID UNIQUEIDENTIFIER` column that links each migration
+   * row to the integration that triggered it. Values are bound as SQL
+   * parameters (safe against injection).
+   *
+   * Extras are always appended to the row shape; they never replace core
+   * Flyway columns. Extras without a `Value` must be nullable or carry a
+   * `DefaultValue`.
+   */
+  HistoryExtraColumns?: HistoryExtraColumn[];
+
+  /**
    * Version string for baseline migrations.
    * When `BaselineOnMigrate` is true and the database has no history,
    * a baseline entry is recorded at this version.
@@ -123,6 +143,7 @@ export function resolveConfig(config: SkywayConfig): Required<SkywayConfig> & { 
       Locations: config.Migrations.Locations,
       DefaultSchema: config.Migrations.DefaultSchema ?? 'dbo',
       HistoryTable: config.Migrations.HistoryTable ?? 'flyway_schema_history',
+      HistoryExtraColumns: config.Migrations.HistoryExtraColumns ?? [],
       BaselineVersion: config.Migrations.BaselineVersion ?? '1',
       BaselineOnMigrate: config.Migrations.BaselineOnMigrate ?? false,
       OutOfOrder: config.Migrations.OutOfOrder ?? false,

--- a/packages/core/src/core/skyway.ts
+++ b/packages/core/src/core/skyway.ts
@@ -194,11 +194,7 @@ export class Skyway {
       await this.connectionManager.Connect();
       const pool = this.connectionManager.GetPool();
 
-      this.historyTable = new HistoryTable(
-        pool,
-        this.config.Migrations.DefaultSchema,
-        this.config.Migrations.HistoryTable
-      );
+      this.historyTable = this.buildHistoryTable(pool);
 
       // Ensure schema and history table exist (outside any migration transaction)
       await this.historyTable.EnsureExists();
@@ -325,11 +321,7 @@ export class Skyway {
     await this.connectionManager.Connect();
     const pool = this.connectionManager.GetPool();
 
-    this.historyTable = new HistoryTable(
-      pool,
-      this.config.Migrations.DefaultSchema,
-      this.config.Migrations.HistoryTable
-    );
+    this.historyTable = this.buildHistoryTable(pool);
 
     const discovered = await ScanAndResolveMigrations(
       this.config.Migrations.Locations
@@ -359,11 +351,7 @@ export class Skyway {
     await this.connectionManager.Connect();
     const pool = this.connectionManager.GetPool();
 
-    this.historyTable = new HistoryTable(
-      pool,
-      this.config.Migrations.DefaultSchema,
-      this.config.Migrations.HistoryTable
-    );
+    this.historyTable = this.buildHistoryTable(pool);
 
     const errors: string[] = [];
 
@@ -624,11 +612,7 @@ export class Skyway {
       await this.connectionManager.Connect();
       const pool = this.connectionManager.GetPool();
 
-      this.historyTable = new HistoryTable(
-        pool,
-        this.config.Migrations.DefaultSchema,
-        this.config.Migrations.HistoryTable
-      );
+      this.historyTable = this.buildHistoryTable(pool);
 
       await this.historyTable.EnsureExists();
 
@@ -687,11 +671,7 @@ export class Skyway {
       await this.connectionManager.Connect();
       const pool = this.connectionManager.GetPool();
 
-      this.historyTable = new HistoryTable(
-        pool,
-        this.config.Migrations.DefaultSchema,
-        this.config.Migrations.HistoryTable
-      );
+      this.historyTable = this.buildHistoryTable(pool);
 
       if (!(await this.historyTable.Exists())) {
         return {
@@ -773,6 +753,19 @@ export class Skyway {
   }
 
   // ─── Private Methods ──────────────────────────────────────────────
+
+  /**
+   * Constructs a HistoryTable bound to the current pool and config.
+   * Centralizes the wiring so every code path picks up `HistoryExtraColumns`.
+   */
+  private buildHistoryTable(pool: sql.ConnectionPool): HistoryTable {
+    return new HistoryTable(
+      pool,
+      this.config.Migrations.DefaultSchema,
+      this.config.Migrations.HistoryTable,
+      this.config.Migrations.HistoryExtraColumns
+    );
+  }
 
   /**
    * Executes pending migrations and records results in the history table.

--- a/packages/core/src/history/history-table.ts
+++ b/packages/core/src/history/history-table.ts
@@ -8,7 +8,7 @@
  */
 
 import * as sql from 'mssql';
-import { HistoryRecord, HistoryRecordType } from './types';
+import { HistoryExtraColumn, HistoryRecord, HistoryRecordType } from './types';
 import { ResolvedMigration } from '../migration/types';
 
 /**
@@ -22,20 +22,26 @@ export class HistoryTable {
   private readonly schema: string;
   private readonly tableName: string;
   private readonly pool: sql.ConnectionPool;
+  private readonly extraColumns: readonly HistoryExtraColumn[];
 
   /**
    * @param pool - Connected SQL Server connection pool
    * @param schema - Schema name (e.g., "__mj" or "dbo")
    * @param tableName - History table name (default: "flyway_schema_history")
+   * @param extraColumns - User-defined columns appended to the standard Flyway
+   *        columns. Created by `EnsureExists` and stamped by every `Insert*`
+   *        call when a `Value` is supplied.
    */
   constructor(
     pool: sql.ConnectionPool,
     schema: string,
-    tableName: string = 'flyway_schema_history'
+    tableName: string = 'flyway_schema_history',
+    extraColumns: readonly HistoryExtraColumn[] = []
   ) {
     this.pool = pool;
     this.schema = schema;
     this.tableName = tableName;
+    this.extraColumns = extraColumns;
   }
 
   /**
@@ -74,6 +80,7 @@ export class HistoryTable {
 
     // Create history table if it doesn't exist
     const createRequest = this.createRequest(connectionSource);
+    const extrasDDL = this.extraColumns.map(c => `,\n          ${this.extraColumnDDL(c)}`).join('');
     await createRequest.batch(`
       IF NOT EXISTS (
         SELECT 1 FROM INFORMATION_SCHEMA.TABLES
@@ -91,13 +98,58 @@ export class HistoryTable {
           [installed_on]    DATETIME       NOT NULL DEFAULT GETDATE(),
           [execution_time]  INT            NOT NULL,
           [success]         BIT            NOT NULL,
-          CONSTRAINT [${this.tableName}_pk] PRIMARY KEY ([installed_rank])
+          CONSTRAINT [${this.tableName}_pk] PRIMARY KEY ([installed_rank])${extrasDDL}
         );
 
         CREATE INDEX [${this.tableName}_s_idx]
           ON ${this.QualifiedName} ([success]);
       END
     `);
+  }
+
+  // ─── Extra-column helpers ─────────────────────────────────────────────
+
+  /**
+   * DDL fragment for one extra column, e.g.
+   * `[CompanyIntegrationID] UNIQUEIDENTIFIER NOT NULL DEFAULT NEWID()`.
+   * Name and SqlType are written verbatim — caller supplies trusted config.
+   */
+  private extraColumnDDL(col: HistoryExtraColumn): string {
+    const nullable = col.IsNullable === false ? 'NOT NULL' : 'NULL';
+    const defaultClause = col.DefaultValue ? ` DEFAULT ${col.DefaultValue}` : '';
+    return `[${col.Name}] ${col.SqlType} ${nullable}${defaultClause}`;
+  }
+
+  /** Extras that have a `Value` — skyway stamps these onto every insert. */
+  private get stampedExtras(): readonly HistoryExtraColumn[] {
+    return this.extraColumns.filter(c => c.Value !== undefined);
+  }
+
+  /** Comma-led column list fragment for INSERT, e.g. `, [ColA], [ColB]`. */
+  private extraInsertColumns(): string {
+    const cols = this.stampedExtras;
+    return cols.length === 0 ? '' : ', ' + cols.map(c => `[${c.Name}]`).join(', ');
+  }
+
+  /** Comma-led values fragment for INSERT, e.g. `, @extra_ColA, @extra_ColB`. */
+  private extraInsertValues(): string {
+    const cols = this.stampedExtras;
+    return cols.length === 0 ? '' : ', ' + cols.map(c => `@${this.extraParamName(c.Name)}`).join(', ');
+  }
+
+  /**
+   * Binds stamped extras onto a request as `@extra_<Name>` parameters so
+   * they flow through mssql's parameterization (safe vs. SQL injection).
+   */
+  private bindExtraValues(request: sql.Request): void {
+    for (const col of this.stampedExtras) {
+      request.input(this.extraParamName(col.Name), col.Value);
+    }
+  }
+
+  /** Prefix avoids collision with core-column parameter names. */
+  private extraParamName(columnName: string): string {
+    return `extra_${columnName}`;
   }
 
   /**
@@ -162,6 +214,7 @@ export class HistoryTable {
     request.input('installedBy', sql.NVarChar(100), user);
     request.input('executionTime', sql.Int, 0);
     request.input('success', sql.Bit, true);
+    this.bindExtraValues(request);
 
     await request.query(`
       IF NOT EXISTS (
@@ -169,10 +222,10 @@ export class HistoryTable {
       )
       INSERT INTO ${this.QualifiedName}
         ([installed_rank], [version], [description], [type], [script],
-         [checksum], [installed_by], [execution_time], [success])
+         [checksum], [installed_by], [execution_time], [success]${this.extraInsertColumns()})
       VALUES
         (@installedRank, NULL, @description, @type, @script,
-         NULL, @installedBy, @executionTime, @success)
+         NULL, @installedBy, @executionTime, @success${this.extraInsertValues()})
     `);
   }
 
@@ -204,14 +257,15 @@ export class HistoryTable {
     request.input('installedBy', sql.NVarChar(100), user);
     request.input('executionTime', sql.Int, executionTimeMS);
     request.input('success', sql.Bit, true);
+    this.bindExtraValues(request);
 
     await request.query(`
       INSERT INTO ${this.QualifiedName}
         ([installed_rank], [version], [description], [type], [script],
-         [checksum], [installed_by], [execution_time], [success])
+         [checksum], [installed_by], [execution_time], [success]${this.extraInsertColumns()})
       VALUES
         (@installedRank, @version, @description, @type, @script,
-         @checksum, @installedBy, @executionTime, @success)
+         @checksum, @installedBy, @executionTime, @success${this.extraInsertValues()})
     `);
   }
 
@@ -243,14 +297,15 @@ export class HistoryTable {
     request.input('installedBy', sql.NVarChar(100), user);
     request.input('executionTime', sql.Int, executionTimeMS);
     request.input('success', sql.Bit, false);
+    this.bindExtraValues(request);
 
     await request.query(`
       INSERT INTO ${this.QualifiedName}
         ([installed_rank], [version], [description], [type], [script],
-         [checksum], [installed_by], [execution_time], [success])
+         [checksum], [installed_by], [execution_time], [success]${this.extraInsertColumns()})
       VALUES
         (@installedRank, @version, @description, @type, @script,
-         @checksum, @installedBy, @executionTime, @success)
+         @checksum, @installedBy, @executionTime, @success${this.extraInsertValues()})
     `);
   }
 
@@ -276,14 +331,15 @@ export class HistoryTable {
     request.input('installedBy', sql.NVarChar(100), user);
     request.input('executionTime', sql.Int, 0);
     request.input('success', sql.Bit, true);
+    this.bindExtraValues(request);
 
     await request.query(`
       INSERT INTO ${this.QualifiedName}
         ([installed_rank], [version], [description], [type], [script],
-         [checksum], [installed_by], [execution_time], [success])
+         [checksum], [installed_by], [execution_time], [success]${this.extraInsertColumns()})
       VALUES
         (@installedRank, @version, @description, @type, @script,
-         NULL, @installedBy, @executionTime, @success)
+         NULL, @installedBy, @executionTime, @success${this.extraInsertValues()})
     `);
   }
 

--- a/packages/core/src/history/history-table.ts
+++ b/packages/core/src/history/history-table.ts
@@ -68,6 +68,7 @@ export class HistoryTable {
    * @param connectionSource - Transaction or pool to execute against
    */
   async EnsureExists(connectionSource?: sql.Transaction): Promise<void> {
+    this.assertExtraColumnsStampable();
     const request = this.createRequest(connectionSource);
 
     // Create schema if it doesn't exist
@@ -105,6 +106,81 @@ export class HistoryTable {
           ON ${this.QualifiedName} ([success]);
       END
     `);
+
+    await this.reconcileExtraColumns(connectionSource);
+  }
+
+  /**
+   * Enforces the documented contract that an extra column without a `Value`
+   * must be nullable or carry a `DefaultValue`. Otherwise the first insert
+   * dies with a bare `Cannot insert the value NULL` and no migrations apply.
+   */
+  private assertExtraColumnsStampable(): void {
+    for (const col of this.extraColumns) {
+      if (col.Value === undefined && col.IsNullable === false && !col.DefaultValue) {
+        throw new Error(
+          `HistoryExtraColumns: column '${col.Name}' is NOT NULL but has no Value and no ` +
+            `DefaultValue, so every history-row insert would fail. Supply a Value, ` +
+            `set a DefaultValue, or declare it nullable (IsNullable: true).`
+        );
+      }
+    }
+  }
+
+  /**
+   * Adds any configured extra column that is missing from an already-existing
+   * history table. Without this, enabling `HistoryExtraColumns` against a
+   * database that Skyway has already migrated leaves the columns absent while
+   * every `Insert*` references them — the run fails with a raw
+   * `Invalid column name` and applies zero migrations.
+   */
+  private async reconcileExtraColumns(connectionSource?: sql.Transaction): Promise<void> {
+    if (this.extraColumns.length === 0) return;
+
+    const existing = await this.existingColumnNames(connectionSource);
+    const missing = this.extraColumns.filter(c => !existing.has(c.Name.toLowerCase()));
+    if (missing.length === 0) return;
+
+    const hasRows = await this.hasAnyRows(connectionSource);
+    for (const col of missing) {
+      this.assertAddable(col, hasRows);
+      await this.createRequest(connectionSource).batch(
+        `ALTER TABLE ${this.QualifiedName} ADD ${this.extraColumnDDL(col)}`
+      );
+    }
+  }
+
+  /** Lower-cased column names currently on the history table. */
+  private async existingColumnNames(connectionSource?: sql.Transaction): Promise<Set<string>> {
+    const request = this.createRequest(connectionSource);
+    request.input('schemaName', sql.NVarChar(128), this.schema);
+    request.input('tableName', sql.NVarChar(128), this.tableName);
+    const result = await request.query<{ COLUMN_NAME: string }>(`
+      SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.COLUMNS
+      WHERE TABLE_SCHEMA = @schemaName AND TABLE_NAME = @tableName
+    `);
+    return new Set(result.recordset.map(r => r.COLUMN_NAME.toLowerCase()));
+  }
+
+  private async hasAnyRows(connectionSource?: sql.Transaction): Promise<boolean> {
+    const result = await this.createRequest(connectionSource).query<{ n: number }>(
+      `SELECT TOP 1 1 AS n FROM ${this.QualifiedName}`
+    );
+    return result.recordset.length > 0;
+  }
+
+  /**
+   * SQL Server cannot add a NOT NULL column to a populated table without a
+   * DEFAULT. Fail with an actionable message instead of a raw engine error.
+   */
+  private assertAddable(col: HistoryExtraColumn, tableHasRows: boolean): void {
+    if (col.IsNullable === false && !col.DefaultValue && tableHasRows) {
+      throw new Error(
+        `HistoryExtraColumns: cannot add NOT NULL column '${col.Name}' to the existing ` +
+          `history table ${this.QualifiedName} because it already contains rows. ` +
+          `Give the column a DefaultValue, or declare it nullable (IsNullable: true).`
+      );
+    }
   }
 
   // ─── Extra-column helpers ─────────────────────────────────────────────

--- a/packages/core/src/history/types.ts
+++ b/packages/core/src/history/types.ts
@@ -14,6 +14,49 @@
 export type HistoryRecordType = 'SCHEMA' | 'SQL' | 'SQL_BASELINE' | 'BASELINE';
 
 /**
+ * Definition of a user-defined extra column on the history table.
+ *
+ * Skyway creates the column during `EnsureExists` and, when `Value` is
+ * supplied, writes it into every history row inserted during the run.
+ * Columns without a `Value` must be nullable or carry a `DefaultValue` so
+ * inserts don't fail.
+ *
+ * Example — stamp each history row with the `CompanyIntegrationID` that
+ * triggered the run:
+ * ```typescript
+ * HistoryExtraColumns: [
+ *   { Name: 'CompanyIntegrationID', SqlType: 'UNIQUEIDENTIFIER', IsNullable: false, Value: companyIntegrationId }
+ * ]
+ * ```
+ */
+export interface HistoryExtraColumn {
+  /** Column name. */
+  Name: string;
+
+  /** Raw SQL type, e.g. `UNIQUEIDENTIFIER`, `NVARCHAR(200)`, `INT`. */
+  SqlType: string;
+
+  /** Whether the column allows NULL. Defaults to `true`. */
+  IsNullable?: boolean;
+
+  /**
+   * SQL literal used as the column's DEFAULT, e.g. `NEWID()`, `GETUTCDATE()`,
+   * `N'Unknown'`. Written verbatim into the `CREATE TABLE` clause.
+   */
+  DefaultValue?: string;
+
+  /**
+   * Value to stamp into this column on every history row written during the
+   * run. Bound as a SQL parameter (safe against injection). If omitted, the
+   * column falls through to its `DefaultValue` or NULL.
+   */
+  Value?: unknown;
+
+  /** Optional human-readable description (currently informational only). */
+  Description?: string;
+}
+
+/**
  * A single row from the `flyway_schema_history` table.
  * Field names match the database column names exactly.
  */

--- a/packages/core/src/history/types.ts
+++ b/packages/core/src/history/types.ts
@@ -16,10 +16,14 @@ export type HistoryRecordType = 'SCHEMA' | 'SQL' | 'SQL_BASELINE' | 'BASELINE';
 /**
  * Definition of a user-defined extra column on the history table.
  *
- * Skyway creates the column during `EnsureExists` and, when `Value` is
- * supplied, writes it into every history row inserted during the run.
- * Columns without a `Value` must be nullable or carry a `DefaultValue` so
- * inserts don't fail.
+ * Skyway creates the column during `EnsureExists` — on a new history table via
+ * `CREATE TABLE`, and on an existing one via `ALTER TABLE ... ADD` — and, when
+ * `Value` is supplied, writes it into every history row inserted during the run.
+ * Columns without a `Value` must be nullable or carry a `DefaultValue`;
+ * `EnsureExists` rejects a configuration that violates this before running any
+ * DDL. Retrofitting a `NOT NULL` column onto a history table that already has
+ * rows additionally requires a `DefaultValue`, since SQL Server cannot add one
+ * without it.
  *
  * Example — stamp each history row with the `CompanyIntegrationID` that
  * triggered the run:

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -69,7 +69,7 @@ export { MigrationExecutionResult, ExecutionCallbacks } from './executor/executo
 
 // ─── History ─────────────────────────────────────────────────────────
 export { HistoryTable } from './history/history-table';
-export { HistoryRecord, HistoryRecordType } from './history/types';
+export { HistoryRecord, HistoryRecordType, HistoryExtraColumn } from './history/types';
 
 // ─── Errors ──────────────────────────────────────────────────────────
 export {


### PR DESCRIPTION
## Summary

- Adds `HistoryExtraColumns` config option — callers can declare user-defined columns on the Skyway history table, created automatically in `EnsureExists` and stamped on every `Insert*`.
- Fixes three call sites (`Migrate`, `Baseline`, `Repair`) that instantiated `HistoryTable` directly without passing `extraColumns`, silently dropping the configured columns. All five construction sites now route through the `buildHistoryTable(pool)` helper.

## Motivation

Consumers like MemberJunction's integration schema builder need to tag each migration row with domain metadata (e.g. `CompanyIntegrationID`, `AffectedTables`). Previously this data had to live in a separate audit table; now it can live directly on the migration-history row.

## Test plan

- [x] Unit tests added in `config.test.ts` covering `HistoryExtraColumns` resolution and defaults
- [x] Verified end-to-end against SQL Server:
  1. Fresh schema, history table created with `CompanyIntegrationID UNIQUEIDENTIFIER NOT NULL` + `AffectedTables NVARCHAR(MAX) NULL`
  2. After `Migrate()`, history rows (schema-creation + migration) both had the configured `Value` stamped correctly

## Files changed

- `packages/core/src/core/config.ts` — `HistoryExtraColumns` config field
- `packages/core/src/core/skyway.ts` — route all `HistoryTable` construction through `buildHistoryTable(pool)` helper
- `packages/core/src/history/history-table.ts` — DDL + stamping logic for extra columns
- `packages/core/src/history/types.ts` — `HistoryExtraColumn` interface
- `packages/core/src/__tests__/config.test.ts` — new tests
- `packages/core/README.md` — docs
- `.changeset/history-extra-columns.md` — changeset
- `packages/core/src/index.ts` — exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)