### PR TITLE
fix: detect duplicate migration versions instead of applying both

### DIFF
--- a/.changeset/tidy-otters-guard.md
+++ b/.changeset/tidy-otters-guard.md
@@ -1,0 +1,5 @@
+---
+"@memberjunction/skyway-core": patch
+---
+
+Detect duplicate migration versions and fail before applying, instead of silently writing two history rows for the same version. Migrate, Info, and Validate now reject version collisions before any database mutation, and Repair refuses to operate when a version is duplicated.

--- a/integration-tests/sqlserver/duplicate-version-smoke.ts
+++ b/integration-tests/sqlserver/duplicate-version-smoke.ts
@@ -85,16 +85,18 @@ export async function runDuplicateVersionSmoke(dbConfig: SqlServerConfig): Promi
       }
     }
 
-    // ─── 3. History must hold zero rows for the duplicate version ──
-    console.log('\n  Verify history has no rows for the duplicate version');
+    // ─── 3. The fresh DB must be untouched — nothing created ───────
+    // The guard runs before EnsureExists, so on a freshly-cleaned database
+    // the duplicate-failing Migrate must not even create the history table.
+    console.log('\n  Verify the duplicate-failing Migrate created nothing');
     {
       const provider = new SqlServerProvider(dbConfig);
       try {
         await provider.Connect();
-        const rows = await provider.Query<{ n: number }>(
-          `SELECT COUNT(*) AS n FROM dbo.flyway_schema_history WHERE version = '${DUP_VERSION}'`
+        const rows = await provider.Query<{ missing: number }>(
+          `SELECT CASE WHEN OBJECT_ID('dbo.flyway_schema_history') IS NULL THEN 1 ELSE 0 END AS missing`
         );
-        check((rows[0]?.n ?? -1) === 0, `0 history rows for version ${DUP_VERSION} (got ${rows[0]?.n})`);
+        check(rows[0]?.missing === 1, 'History table was not created (nothing reached the DB)');
       } finally {
         await provider.Disconnect();
       }

--- a/integration-tests/sqlserver/duplicate-version-smoke.ts
+++ b/integration-tests/sqlserver/duplicate-version-smoke.ts
@@ -1,0 +1,162 @@
+/**
+ * Smoke test for duplicate-version detection.
+ *
+ * Proves end-to-end against a real SQL Server that two migration files
+ * sharing a version are rejected before anything is applied — the bug
+ * (seen in the real `mj_duplicate` database) applied both, writing two
+ * history rows for one version.
+ *
+ * Phases (all against a throwaway temp migrations dir, so the main run.ts
+ * lifecycle fixtures are untouched):
+ *   1. Pre-clean (idempotent re-runs)
+ *   2. Migrate with two V202606021200 files → Success: false, 0 applied
+ *   3. Query history → zero rows for the duplicate version (no double-apply)
+ *   4. Info → throws (hard-fail)
+ *   5. Validate → Valid: false with the duplicate error
+ *   6. Remove one duplicate → Migrate applies the remaining file (detection
+ *      does not over-block a legitimate run)
+ *   7. Clean
+ *
+ * Exported as a function so run.ts can invoke it as a phase using its own
+ * connection config; returns the number of failed assertions.
+ */
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { Skyway } from '../../packages/core/src/index';
+import { SqlServerProvider } from '../../packages/sqlserver/src/index';
+
+type SqlServerConfig = ConstructorParameters<typeof SqlServerProvider>[0];
+
+const DUP_VERSION = '202606021200';
+
+export async function runDuplicateVersionSmoke(dbConfig: SqlServerConfig): Promise<number> {
+  let failures = 0;
+  const check = (condition: boolean, message: string): void => {
+    if (condition) {
+      console.log(`  ✓ ${message}`);
+    } else {
+      console.error(`  ✗ ${message}`);
+      failures++;
+    }
+  };
+
+  // Throwaway dir with two files claiming the same version.
+  const migrationsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skyway-dup-smoke-'));
+  fs.writeFileSync(path.join(migrationsDir, `V${DUP_VERSION}__First.sql`), 'CREATE TABLE dbo.dup_first (id INT);\n');
+  fs.writeFileSync(path.join(migrationsDir, `V${DUP_VERSION}__Second.sql`), 'CREATE TABLE dbo.dup_second (id INT);\n');
+
+  const makeSkyway = (): Skyway =>
+    new Skyway({
+      Provider: new SqlServerProvider(dbConfig),
+      Migrations: { Locations: [migrationsDir], DefaultSchema: 'dbo' },
+      TransactionMode: 'per-migration',
+    }).OnProgress({ OnLog: (msg) => console.log(`    [LOG] ${msg}`) });
+
+  console.log(`Temp migrations dir: ${migrationsDir} (two files at version ${DUP_VERSION})`);
+
+  try {
+    // ─── 1. Idempotent pre-clean ───────────────────────────────────
+    {
+      const skyway = makeSkyway();
+      try {
+        const clean = await skyway.Clean();
+        console.log(`    pre-clean dropped ${clean.ObjectsDropped} object(s); success=${clean.Success}`);
+      } finally {
+        await skyway.Close();
+      }
+    }
+
+    // ─── 2. Migrate must fail fast and apply nothing ───────────────
+    console.log('\n  Migrate (duplicate) — expect failure, nothing applied');
+    {
+      const skyway = makeSkyway();
+      try {
+        const result = await skyway.Migrate();
+        check(!result.Success, `Migrate failed${result.ErrorMessage ? ` (${result.ErrorMessage})` : ''}`);
+        check(
+          /Found more than one migration with version 202606021200/.test(result.ErrorMessage ?? ''),
+          'Error names the duplicate version'
+        );
+        check(result.MigrationsApplied === 0, `Applied 0 (got ${result.MigrationsApplied})`);
+      } finally {
+        await skyway.Close();
+      }
+    }
+
+    // ─── 3. History must hold zero rows for the duplicate version ──
+    console.log('\n  Verify history has no rows for the duplicate version');
+    {
+      const provider = new SqlServerProvider(dbConfig);
+      try {
+        await provider.Connect();
+        const rows = await provider.Query<{ n: number }>(
+          `SELECT COUNT(*) AS n FROM dbo.flyway_schema_history WHERE version = '${DUP_VERSION}'`
+        );
+        check((rows[0]?.n ?? -1) === 0, `0 history rows for version ${DUP_VERSION} (got ${rows[0]?.n})`);
+      } finally {
+        await provider.Disconnect();
+      }
+    }
+
+    // ─── 4. Info must hard-fail ────────────────────────────────────
+    console.log('\n  Info (duplicate) — expect throw');
+    {
+      const skyway = makeSkyway();
+      try {
+        await skyway.Info();
+        check(false, 'Info threw on duplicates');
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        check(/Found more than one migration with version/.test(msg), `Info threw with the duplicate message (${msg})`);
+      } finally {
+        await skyway.Close();
+      }
+    }
+
+    // ─── 5. Validate must report invalid ───────────────────────────
+    console.log('\n  Validate (duplicate) — expect invalid');
+    {
+      const skyway = makeSkyway();
+      try {
+        const validate = await skyway.Validate();
+        check(!validate.Valid, 'Validate reports invalid');
+        check(
+          validate.Errors.some((e) => /Found more than one migration with version/.test(e)),
+          'Validate error names the duplicate'
+        );
+      } finally {
+        await skyway.Close();
+      }
+    }
+
+    // ─── 6. Resolving the collision lets the run proceed ───────────
+    console.log('\n  Remove one duplicate, Migrate — expect single apply');
+    fs.rmSync(path.join(migrationsDir, `V${DUP_VERSION}__Second.sql`));
+    {
+      const skyway = makeSkyway();
+      try {
+        const result = await skyway.Migrate();
+        check(result.Success, `Migrate succeeded${result.ErrorMessage ? ` (${result.ErrorMessage})` : ''}`);
+        check(result.MigrationsApplied === 1, `Applied 1 (got ${result.MigrationsApplied})`);
+      } finally {
+        await skyway.Close();
+      }
+    }
+
+    // ─── 7. Clean ──────────────────────────────────────────────────
+    {
+      const skyway = makeSkyway();
+      try {
+        await skyway.Clean();
+      } finally {
+        await skyway.Close();
+      }
+    }
+  } finally {
+    fs.rmSync(migrationsDir, { recursive: true, force: true });
+  }
+
+  return failures;
+}

--- a/integration-tests/sqlserver/run.ts
+++ b/integration-tests/sqlserver/run.ts
@@ -28,6 +28,7 @@
 
 import { Skyway } from '../../packages/core/src/index';
 import { SqlServerProvider } from '../../packages/sqlserver/src/index';
+import { runDuplicateVersionSmoke } from './duplicate-version-smoke';
 
 const DB_CONFIG = {
   Dialect: 'sqlserver' as const,
@@ -113,6 +114,10 @@ async function main() {
     check(clean.Success, `Clean succeeded${clean.ErrorMessage ? ` (${clean.ErrorMessage})` : ''}`);
     check(clean.ObjectsDropped > 0, `Clean dropped objects (got ${clean.ObjectsDropped})`);
     for (const obj of clean.DroppedObjects) console.log(`      - ${obj}`);
+
+    // Phase 7 — Duplicate-version detection (own temp dir, leaves DB clean)
+    console.log('\n--- 7. Duplicate-version detection ---');
+    failures += await runDuplicateVersionSmoke(DB_CONFIG);
 
     if (failures > 0) {
       console.log(`\n=== FAILED — ${failures} assertion(s) failed ===`);

--- a/packages/core/src/__tests__/migrate.test.ts
+++ b/packages/core/src/__tests__/migrate.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Unit tests for `Skyway.Migrate()` duplicate-version handling.
+ *
+ * The regression these guard: two migration files on disk that share a
+ * version were both marked PENDING and BOTH applied (two history rows for
+ * one version, as seen in the real `mj_duplicate` database). Migrate() must
+ * now fail fast before applying anything.
+ *
+ * Uses an in-memory fake provider with a working (no-op) transaction so the
+ * double-apply actually reproduces pre-fix — both migrations would otherwise
+ * execute and insert. Real-DB coverage lives in
+ * integration-tests/sqlserver/duplicate-version-smoke.ts.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
+import { Skyway } from '../core/skyway';
+import { HistoryRecord } from '../history/types';
+import {
+  DatabaseProvider,
+  ProviderTransaction,
+  HistoryTableProvider,
+  HistoryInsertParams,
+  CleanOperation,
+} from '../db/provider';
+import { DatabaseConfig } from '../db/types';
+import { SQLBatch } from '../executor/sql-splitter';
+
+// ─── Fake provider (drives Migrate end-to-end) ───────────────────────
+
+class FakeHistoryProvider implements HistoryTableProvider {
+  records: HistoryRecord[] = [];
+  exists = false;
+
+  async EnsureExists(): Promise<void> {
+    this.exists = true;
+  }
+  async Exists(): Promise<boolean> {
+    return this.exists;
+  }
+  async GetAllRecords(): Promise<HistoryRecord[]> {
+    return [...this.records];
+  }
+  async GetNextRank(): Promise<number> {
+    let max = -1;
+    for (const r of this.records) if (r.InstalledRank > max) max = r.InstalledRank;
+    return max + 1;
+  }
+  async InsertRecord(_s: string, _t: string, p: HistoryInsertParams): Promise<void> {
+    this.records.push({ ...p, InstalledOn: new Date() } as HistoryRecord);
+  }
+  async DeleteRecord(_s: string, _t: string, rank: number): Promise<void> {
+    this.records = this.records.filter((r) => r.InstalledRank !== rank);
+  }
+  async UpdateChecksum(_s: string, _t: string, rank: number, c: number): Promise<void> {
+    const r = this.records.find((x) => x.InstalledRank === rank);
+    if (r) r.Checksum = c;
+  }
+
+  /** Migration rows only — excludes the rank-0 SCHEMA creation marker. */
+  migrationRows(): HistoryRecord[] {
+    return this.records.filter((r) => r.Type !== 'SCHEMA');
+  }
+}
+
+class FakeProvider implements DatabaseProvider {
+  readonly Dialect = 'sqlserver' as const;
+  readonly DefaultSchema = 'dbo';
+  readonly DefaultPort = 1433;
+  readonly Config: DatabaseConfig;
+  readonly History = new FakeHistoryProvider();
+
+  IsConnected = false;
+
+  constructor(config: DatabaseConfig) {
+    this.Config = config;
+  }
+
+  async Connect(): Promise<void> {
+    this.IsConnected = true;
+  }
+  async Disconnect(): Promise<void> {
+    this.IsConnected = false;
+  }
+  async DatabaseExists(): Promise<boolean> {
+    return true;
+  }
+  async CreateDatabase(): Promise<void> {}
+  async DropDatabase(): Promise<void> {}
+  async BeginTransaction(): Promise<ProviderTransaction> {
+    // Working no-op transaction so migrations actually "apply".
+    return {
+      async Execute(): Promise<void> {},
+      async Query<T>(): Promise<T[]> {
+        return [];
+      },
+      async Commit(): Promise<void> {},
+      async Rollback(): Promise<void> {},
+    };
+  }
+  async Execute(): Promise<void> {}
+  async Query<T>(): Promise<T[]> {
+    return [];
+  }
+  SplitScript(script: string): SQLBatch[] {
+    return [{ SQL: script, RepeatCount: 1, StartLine: 1, EndLine: 1 }];
+  }
+  async GetCleanOperations(): Promise<CleanOperation[]> {
+    return [];
+  }
+  async DropSchema(): Promise<void> {}
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+let migrationsDir: string;
+
+beforeEach(() => {
+  migrationsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skyway-migrate-'));
+});
+
+afterEach(() => {
+  if (fs.existsSync(migrationsDir)) fs.rmSync(migrationsDir, { recursive: true, force: true });
+});
+
+function writeMigration(filename: string, sql = 'SELECT 1;\n'): void {
+  fs.writeFileSync(path.join(migrationsDir, filename), sql);
+}
+
+function makeSkyway(provider: FakeProvider): Skyway {
+  return new Skyway({
+    Provider: provider,
+    Database: provider.Config,
+    Migrations: { Locations: [migrationsDir], DefaultSchema: 'dbo' },
+  });
+}
+
+const config: DatabaseConfig = {
+  Server: 'localhost',
+  Database: 'test',
+  User: 'sa',
+  Password: 'x',
+};
+
+// ─── Tests ───────────────────────────────────────────────────────────
+
+describe('Skyway.Migrate() — duplicate versions', () => {
+  it('fails fast and applies nothing when two files share a version', async () => {
+    const provider = new FakeProvider(config);
+    writeMigration('V202606021200__First.sql');
+    writeMigration('V202606021200__Second.sql');
+
+    const result = await makeSkyway(provider).Migrate();
+
+    expect(result.Success).toBe(false);
+    expect(result.ErrorMessage).toMatch(/Found more than one migration with version 202606021200/);
+    expect(result.MigrationsApplied).toBe(0);
+    // The core regression: neither duplicate may reach the history table.
+    expect(provider.History.migrationRows()).toHaveLength(0);
+  });
+
+  it('does not apply duplicates even in dry-run mode', async () => {
+    const provider = new FakeProvider(config);
+    writeMigration('V202606021200__First.sql');
+    writeMigration('V202606021200__Second.sql');
+
+    const skyway = new Skyway({
+      Provider: provider,
+      Database: provider.Config,
+      Migrations: { Locations: [migrationsDir], DefaultSchema: 'dbo' },
+      DryRun: true,
+    });
+    const result = await skyway.Migrate();
+
+    expect(result.Success).toBe(false);
+    expect(result.ErrorMessage).toMatch(/Found more than one migration with version 202606021200/);
+    expect(provider.History.migrationRows()).toHaveLength(0);
+  });
+
+  it('still applies distinct versions normally (negative control)', async () => {
+    const provider = new FakeProvider(config);
+    writeMigration('V202606021200__First.sql');
+    writeMigration('V202606021300__Second.sql');
+
+    const result = await makeSkyway(provider).Migrate();
+
+    expect(result.Success).toBe(true);
+    expect(result.MigrationsApplied).toBe(2);
+    expect(provider.History.migrationRows()).toHaveLength(2);
+  });
+});

--- a/packages/core/src/__tests__/repair.test.ts
+++ b/packages/core/src/__tests__/repair.test.ts
@@ -1,15 +1,13 @@
 /**
- * Unit tests for `Skyway.Migrate()` duplicate-version handling.
+ * Unit tests for `Skyway.Repair()` duplicate-version handling.
  *
- * The regression these guard: two migration files on disk that share a
- * version were both marked PENDING and BOTH applied (two history rows for
- * one version, as seen in the real `mj_duplicate` database). Migrate() must
- * now fail fast before applying anything.
+ * Repair builds a disk-by-version map (last-write-wins on readdir order) to
+ * realign checksums. With two files sharing a version that mapping is
+ * ambiguous — the exact problem duplicate detection exists to prevent — so
+ * Repair must refuse before mutating the history table (removing failed
+ * entries / realigning checksums).
  *
- * Uses an in-memory fake provider with a working (no-op) transaction so the
- * double-apply actually reproduces pre-fix — both migrations would otherwise
- * execute and insert. Real-DB coverage lives in
- * integration-tests/sqlserver/duplicate-version-smoke.ts.
+ * Uses an in-memory fake provider; Repair touches no transactions.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import * as fs from 'node:fs';
@@ -28,11 +26,11 @@ import {
 import { DatabaseConfig } from '../db/types';
 import { SQLBatch } from '../executor/sql-splitter';
 
-// ─── Fake provider (drives Migrate end-to-end) ───────────────────────
+// ─── Fake provider (drives Repair) ───────────────────────────────────
 
 class FakeHistoryProvider implements HistoryTableProvider {
   records: HistoryRecord[] = [];
-  exists = false;
+  exists = true;
 
   async EnsureExists(): Promise<void> {
     this.exists = true;
@@ -57,11 +55,6 @@ class FakeHistoryProvider implements HistoryTableProvider {
   async UpdateChecksum(_s: string, _t: string, rank: number, c: number): Promise<void> {
     const r = this.records.find((x) => x.InstalledRank === rank);
     if (r) r.Checksum = c;
-  }
-
-  /** Migration rows only — excludes the rank-0 SCHEMA creation marker. */
-  migrationRows(): HistoryRecord[] {
-    return this.records.filter((r) => r.Type !== 'SCHEMA');
   }
 }
 
@@ -90,15 +83,7 @@ class FakeProvider implements DatabaseProvider {
   async CreateDatabase(): Promise<void> {}
   async DropDatabase(): Promise<void> {}
   async BeginTransaction(): Promise<ProviderTransaction> {
-    // Working no-op transaction so migrations actually "apply".
-    return {
-      async Execute(): Promise<void> {},
-      async Query<T>(): Promise<T[]> {
-        return [];
-      },
-      async Commit(): Promise<void> {},
-      async Rollback(): Promise<void> {},
-    };
+    throw new Error('not used in Repair tests');
   }
   async Execute(): Promise<void> {}
   async Query<T>(): Promise<T[]> {
@@ -118,7 +103,7 @@ class FakeProvider implements DatabaseProvider {
 let migrationsDir: string;
 
 beforeEach(() => {
-  migrationsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skyway-migrate-'));
+  migrationsDir = fs.mkdtempSync(path.join(os.tmpdir(), 'skyway-repair-'));
 });
 
 afterEach(() => {
@@ -127,6 +112,21 @@ afterEach(() => {
 
 function writeMigration(filename: string, sql = 'SELECT 1;\n'): void {
   fs.writeFileSync(path.join(migrationsDir, filename), sql);
+}
+
+function makeHistoryRecord(overrides: Partial<HistoryRecord> & { Version: string | null }): HistoryRecord {
+  return {
+    InstalledRank: overrides.InstalledRank ?? 1,
+    Version: overrides.Version,
+    Description: overrides.Description ?? 'desc',
+    Type: overrides.Type ?? 'SQL',
+    Script: overrides.Script ?? 'V_x.sql',
+    Checksum: overrides.Checksum ?? null,
+    InstalledBy: overrides.InstalledBy ?? 'sa',
+    InstalledOn: overrides.InstalledOn ?? new Date('2026-01-01'),
+    ExecutionTime: overrides.ExecutionTime ?? 0,
+    Success: overrides.Success ?? true,
+  };
 }
 
 function makeSkyway(provider: FakeProvider): Skyway {
@@ -146,52 +146,39 @@ const config: DatabaseConfig = {
 
 // ─── Tests ───────────────────────────────────────────────────────────
 
-describe('Skyway.Migrate() — duplicate versions', () => {
-  it('fails fast and applies nothing when two files share a version', async () => {
+describe('Skyway.Repair() — duplicate versions', () => {
+  it('fails and mutates nothing when two files share a version', async () => {
     const provider = new FakeProvider(config);
+    provider.History.records = [
+      makeHistoryRecord({ InstalledRank: 1, Version: '202601010000', Description: 'failed one', Success: false }),
+      makeHistoryRecord({ InstalledRank: 2, Version: '202606021200', Description: 'applied', Checksum: 999 }),
+    ];
     writeMigration('V202606021200__First.sql');
     writeMigration('V202606021200__Second.sql');
 
-    const result = await makeSkyway(provider).Migrate();
+    const result = await makeSkyway(provider).Repair();
 
     expect(result.Success).toBe(false);
     expect(result.ErrorMessage).toMatch(/Found more than one migration with version 202606021200/);
-    expect(result.MigrationsApplied).toBe(0);
-    // The guard runs before EnsureExists, so on a fresh database nothing is
-    // created — not the history table, not the rank-0 schema marker, no rows.
-    expect(provider.History.exists).toBe(false);
-    expect(provider.History.records).toHaveLength(0);
+    expect(result.FailedEntriesRemoved).toBe(0);
+    expect(result.ChecksumsRealigned).toBe(0);
+    // Guard runs before any mutation: failed entry still present, checksum untouched.
+    expect(provider.History.records.some((r) => r.Success === false)).toBe(true);
+    expect(provider.History.records.find((r) => r.Version === '202606021200')?.Checksum).toBe(999);
   });
 
-  it('does not apply duplicates even in dry-run mode', async () => {
+  it('still repairs normally when versions are distinct (negative control)', async () => {
     const provider = new FakeProvider(config);
-    writeMigration('V202606021200__First.sql');
-    writeMigration('V202606021200__Second.sql');
+    provider.History.records = [
+      makeHistoryRecord({ InstalledRank: 1, Version: '202601010000', Description: 'failed one', Success: false }),
+      makeHistoryRecord({ InstalledRank: 2, Version: '202606021200', Description: 'drifted checksum', Checksum: 999 }),
+    ];
+    writeMigration('V202606021200__drifted.sql', 'SELECT 1;\n');
 
-    const skyway = new Skyway({
-      Provider: provider,
-      Database: provider.Config,
-      Migrations: { Locations: [migrationsDir], DefaultSchema: 'dbo' },
-      DryRun: true,
-    });
-    const result = await skyway.Migrate();
-
-    expect(result.Success).toBe(false);
-    expect(result.ErrorMessage).toMatch(/Found more than one migration with version 202606021200/);
-    // Same fresh-DB guarantee holds in dry-run: nothing reaches the database.
-    expect(provider.History.exists).toBe(false);
-    expect(provider.History.records).toHaveLength(0);
-  });
-
-  it('still applies distinct versions normally (negative control)', async () => {
-    const provider = new FakeProvider(config);
-    writeMigration('V202606021200__First.sql');
-    writeMigration('V202606021300__Second.sql');
-
-    const result = await makeSkyway(provider).Migrate();
+    const result = await makeSkyway(provider).Repair();
 
     expect(result.Success).toBe(true);
-    expect(result.MigrationsApplied).toBe(2);
-    expect(provider.History.migrationRows()).toHaveLength(2);
+    expect(result.FailedEntriesRemoved).toBe(1);
+    expect(result.ChecksumsRealigned).toBe(1);
   });
 });

--- a/packages/core/src/__tests__/resolver.test.ts
+++ b/packages/core/src/__tests__/resolver.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { ResolveMigrations } from '../migration/resolver';
+import { ResolveMigrations, DetectDuplicateMigrations } from '../migration/resolver';
 import { ResolvedMigration } from '../migration/types';
 import { HistoryRecord } from '../history/types';
+import { DuplicateVersionError } from '../core/errors';
 
 // ─── Test Helpers ────────────────────────────────────────────────────
 
@@ -1094,5 +1095,106 @@ describe('ResolveMigrations — baseline floor edge cases', () => {
     const r = result.StatusReport.find((s) => s.Description === 'RefreshViews');
     expect(r?.State).toBe('PENDING');
     expect(result.PendingMigrations.map((m) => m.Type)).toContain('repeatable');
+  });
+});
+
+// ─── Duplicate-Version Detection ─────────────────────────────────────
+
+describe('DetectDuplicateMigrations', () => {
+  it('flags two versioned files sharing a version', () => {
+    const discovered = [
+      makeMigration({ Version: '202606021200', Description: 'First', ScriptPath: 'V202606021200__First.sql' }),
+      makeMigration({ Version: '202606021200', Description: 'Second', ScriptPath: 'V202606021200__Second.sql' }),
+    ];
+
+    const groups = DetectDuplicateMigrations(discovered);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].Version).toBe('202606021200');
+    expect(groups[0].Scripts).toEqual(
+      expect.arrayContaining(['V202606021200__First.sql', 'V202606021200__Second.sql'])
+    );
+    expect(groups[0].Scripts).toHaveLength(2);
+  });
+
+  it('flags a baseline and a versioned sharing a version (shared namespace)', () => {
+    const discovered = [
+      makeMigration({ Type: 'versioned', Version: '202606021200', Description: 'V file' }),
+      makeMigration({ Type: 'baseline', Version: '202606021200', Description: 'B file' }),
+    ];
+
+    const groups = DetectDuplicateMigrations(discovered);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].Version).toBe('202606021200');
+    expect(groups[0].Scripts).toHaveLength(2);
+  });
+
+  it('flags two baseline files sharing a version', () => {
+    const discovered = [
+      makeMigration({ Type: 'baseline', Version: '202606021200', Description: 'B one' }),
+      makeMigration({ Type: 'baseline', Version: '202606021200', Description: 'B two' }),
+    ];
+
+    expect(DetectDuplicateMigrations(discovered)).toHaveLength(1);
+  });
+
+  it('treats lowercase v and uppercase V with same version as a collision', () => {
+    // The parser uppercases the prefix and keeps a digits-only Version, so
+    // both resolve to Type=versioned, Version=202606021200.
+    const discovered = [
+      makeMigration({ Version: '202606021200', Filename: 'v202606021200__lower.sql', ScriptPath: 'v202606021200__lower.sql' }),
+      makeMigration({ Version: '202606021200', Filename: 'V202606021200__upper.sql', ScriptPath: 'V202606021200__upper.sql' }),
+    ];
+
+    expect(DetectDuplicateMigrations(discovered)).toHaveLength(1);
+  });
+
+  it('returns empty when all versions are distinct', () => {
+    const discovered = [
+      makeMigration({ Version: '202606021200', Description: 'a' }),
+      makeMigration({ Version: '202606021201', Description: 'b' }),
+      makeMigration({ Type: 'baseline', Version: '202606021202', Description: 'c' }),
+    ];
+
+    expect(DetectDuplicateMigrations(discovered)).toEqual([]);
+  });
+
+  it('ignores repeatable migrations (no version)', () => {
+    const discovered = [
+      makeMigration({ Type: 'repeatable', Version: null, Description: 'Refresh Views' }),
+      makeMigration({ Type: 'repeatable', Version: null, Description: 'Refresh Views' }),
+    ];
+
+    expect(DetectDuplicateMigrations(discovered)).toEqual([]);
+  });
+
+  it('reports each distinct collision as its own group', () => {
+    const discovered = [
+      makeMigration({ Version: '202606021200', Description: 'a1' }),
+      makeMigration({ Version: '202606021200', Description: 'a2' }),
+      makeMigration({ Version: '202606021300', Description: 'b1' }),
+      makeMigration({ Version: '202606021300', Description: 'b2' }),
+      makeMigration({ Version: '202606021400', Description: 'c (unique)' }),
+    ];
+
+    const groups = DetectDuplicateMigrations(discovered);
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.Version).sort()).toEqual(['202606021200', '202606021300']);
+  });
+});
+
+describe('DuplicateVersionError', () => {
+  it('carries the DUPLICATE_VERSION code and lists the colliding scripts', () => {
+    const err = new DuplicateVersionError([
+      { Version: '202606021200', Scripts: ['V202606021200__First.sql', 'V202606021200__Second.sql'] },
+    ]);
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.Code).toBe('DUPLICATE_VERSION');
+    expect(err.message).toMatch(/Found more than one migration with version 202606021200/);
+    expect(err.message).toContain('V202606021200__First.sql');
+    expect(err.message).toContain('V202606021200__Second.sql');
+    expect(err.Duplicates).toHaveLength(1);
   });
 });

--- a/packages/core/src/__tests__/validate.test.ts
+++ b/packages/core/src/__tests__/validate.test.ts
@@ -483,3 +483,63 @@ describe('Skyway.Validate() — edge cases', () => {
     expect(result.Errors).toHaveLength(0);
   });
 });
+
+// ─── Validate() — duplicate versions on disk ─────────────────────────
+
+describe('Skyway.Validate() — duplicate versions', () => {
+  it('flags two versioned files sharing a version', async () => {
+    const provider = new FakeProvider({
+      Server: 'localhost',
+      Database: 'test',
+      User: 'sa',
+      Password: 'x',
+    });
+    writeMigration('V202606021200__First.sql');
+    writeMigration('V202606021200__Second.sql');
+
+    const result = await makeSkyway(provider).Validate();
+    expect(result.Valid).toBe(false);
+    expect(result.Errors.some((e) => /Found more than one migration with version 202606021200/.test(e))).toBe(true);
+    const dupError = result.Errors.find((e) => /Found more than one migration/.test(e))!;
+    expect(dupError).toContain('V202606021200__First.sql');
+    expect(dupError).toContain('V202606021200__Second.sql');
+  });
+
+  it('flags a baseline and a versioned sharing a version', async () => {
+    const provider = new FakeProvider({
+      Server: 'localhost',
+      Database: 'test',
+      User: 'sa',
+      Password: 'x',
+    });
+    writeMigration('V202606021200__A.sql');
+    writeMigration('B202606021200__B.sql');
+
+    const result = await makeSkyway(provider).Validate();
+    expect(result.Valid).toBe(false);
+    expect(result.Errors.some((e) => /Found more than one migration with version 202606021200/.test(e))).toBe(true);
+  });
+
+  it('flags a duplicate even when that version is already applied in history', async () => {
+    const provider = new FakeProvider({
+      Server: 'localhost',
+      Database: 'test',
+      User: 'sa',
+      Password: 'x',
+    });
+    provider.History.records = [
+      makeHistoryRecord({
+        InstalledRank: 1,
+        Version: '202606021200',
+        Type: 'SQL',
+        Description: 'First',
+      }),
+    ];
+    writeMigration('V202606021200__First.sql');
+    writeMigration('V202606021200__Second.sql');
+
+    const result = await makeSkyway(provider).Validate();
+    expect(result.Valid).toBe(false);
+    expect(result.Errors.some((e) => /Found more than one migration with version 202606021200/.test(e))).toBe(true);
+  });
+});

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -3,6 +3,8 @@
  * Custom error types for Skyway migration operations.
  */
 
+import type { DuplicateVersionGroup } from '../migration/types';
+
 /**
  * Base error class for all Skyway errors.
  * Provides a consistent error hierarchy with error codes for programmatic handling.
@@ -120,6 +122,31 @@ export class ChecksumMismatchError extends SkywayError {
     this.Version = version;
     this.ExpectedChecksum = expected;
     this.ActualChecksum = actual;
+  }
+}
+
+/**
+ * Thrown when two or more migration files on disk share the same version.
+ * Applying both would write duplicate history rows, so resolution cannot
+ * proceed. Mirrors Flyway's "Found more than one migration with version X".
+ */
+export class DuplicateVersionError extends SkywayError {
+  /** Every version collision detected (usually one). */
+  readonly Duplicates: DuplicateVersionGroup[];
+
+  constructor(duplicates: DuplicateVersionGroup[]) {
+    super('DUPLICATE_VERSION', DuplicateVersionError.buildMessage(duplicates));
+    this.name = 'DuplicateVersionError';
+    this.Duplicates = duplicates;
+  }
+
+  private static buildMessage(duplicates: DuplicateVersionGroup[]): string {
+    return duplicates
+      .map(
+        (group) =>
+          `Found more than one migration with version ${group.Version}: ${group.Scripts.join(', ')}`
+      )
+      .join('; ');
   }
 }
 

--- a/packages/core/src/core/skyway.ts
+++ b/packages/core/src/core/skyway.ts
@@ -33,9 +33,10 @@ import { SkywayConfig, ResolvedSkywayConfig, resolveConfig } from './config';
 import { DatabaseProvider, ProviderTransaction, HistoryInsertParams } from '../db/provider';
 import { HistoryRecord } from '../history/types';
 import { ScanAndResolveMigrations } from '../migration/scanner';
-import { ResolveMigrations, ResolverResult } from '../migration/resolver';
+import { ResolveMigrations, ResolverResult, DetectDuplicateMigrations } from '../migration/resolver';
 import { ResolvedMigration, MigrationStatus } from '../migration/types';
 import { SubstitutePlaceholders, PlaceholderContext } from '../executor/placeholder';
+import { DuplicateVersionError } from './errors';
 
 /**
  * Result of a `Migrate()` operation.
@@ -244,6 +245,10 @@ export class Skyway {
       );
       this.callbacks.OnLog?.(`Found ${discovered.length} migration file(s)`);
 
+      // Reject duplicate versions before resolving/executing — applying both
+      // would write duplicate history rows. Caught by this method's try/catch.
+      this.assertNoDuplicateVersions(discovered);
+
       // Re-read history (may have changed after schema creation)
       const currentHistory = await this.provider.History.GetAllRecords(schema, historyTable);
 
@@ -353,6 +358,9 @@ export class Skyway {
       this.config.Migrations.Locations
     );
 
+    // Duplicate versions make the status report ambiguous — fail fast.
+    this.assertNoDuplicateVersions(discovered);
+
     let applied: HistoryRecord[] = [];
     if (await this.provider.History.Exists(schema, historyTable)) {
       applied = await this.provider.History.GetAllRecords(schema, historyTable);
@@ -380,14 +388,22 @@ export class Skyway {
     const historyTable = this.config.Migrations.HistoryTable;
     const errors: string[] = [];
 
-    if (!(await this.provider.History.Exists(schema, historyTable))) {
-      return { Valid: true, Errors: [] };
-    }
-
-    const applied = await this.provider.History.GetAllRecords(schema, historyTable);
+    // Duplicate versions on disk are a problem regardless of DB state, so
+    // check before the no-history-table short-circuit below.
     const discovered = await ScanAndResolveMigrations(
       this.config.Migrations.Locations
     );
+    for (const dup of DetectDuplicateMigrations(discovered)) {
+      errors.push(
+        `Found more than one migration with version ${dup.Version}: ${dup.Scripts.join(', ')}`
+      );
+    }
+
+    if (!(await this.provider.History.Exists(schema, historyTable))) {
+      return { Valid: errors.length === 0, Errors: errors };
+    }
+
+    const applied = await this.provider.History.GetAllRecords(schema, historyTable);
 
     // Build lookup by version
     const diskByVersion = new Map<string, ResolvedMigration>();
@@ -688,6 +704,17 @@ export class Skyway {
   }
 
   // ─── Private Methods ──────────────────────────────────────────────
+
+  /**
+   * Throws DuplicateVersionError if two discovered files share a version.
+   * Run before resolution so duplicates never reach execution.
+   */
+  private assertNoDuplicateVersions(discovered: ResolvedMigration[]): void {
+    const duplicates = DetectDuplicateMigrations(discovered);
+    if (duplicates.length > 0) {
+      throw new DuplicateVersionError(duplicates);
+    }
+  }
 
   /**
    * Inserts the schema creation marker (installed_rank 0).

--- a/packages/core/src/core/skyway.ts
+++ b/packages/core/src/core/skyway.ts
@@ -227,6 +227,17 @@ export class Skyway {
       const schema = this.config.Migrations.DefaultSchema;
       const historyTable = this.config.Migrations.HistoryTable;
 
+      // Scan migrations and reject duplicate versions BEFORE any DB mutation.
+      // Detection is DB-independent, so an invalid migration set must not
+      // create the schema, history table, or schema marker on a fresh database.
+      this.callbacks.OnLog?.('Scanning migration files...');
+      const discovered = await ScanAndResolveMigrations(
+        this.config.Migrations.Locations,
+        (warning) => this.callbacks.OnLog?.(`Warning: ${warning}`)
+      );
+      this.callbacks.OnLog?.(`Found ${discovered.length} migration file(s)`);
+      this.assertNoDuplicateVersions(discovered);
+
       // Ensure schema and history table exist
       await this.provider.History.EnsureExists(schema, historyTable);
 
@@ -236,18 +247,6 @@ export class Skyway {
         await this.insertSchemaMarker(schema, historyTable);
         this.callbacks.OnLog?.(`Created schema [${schema}]`);
       }
-
-      // Scan and resolve migrations
-      this.callbacks.OnLog?.('Scanning migration files...');
-      const discovered = await ScanAndResolveMigrations(
-        this.config.Migrations.Locations,
-        (warning) => this.callbacks.OnLog?.(`Warning: ${warning}`)
-      );
-      this.callbacks.OnLog?.(`Found ${discovered.length} migration file(s)`);
-
-      // Reject duplicate versions before resolving/executing — applying both
-      // would write duplicate history rows. Caught by this method's try/catch.
-      this.assertNoDuplicateVersions(discovered);
 
       // Re-read history (may have changed after schema creation)
       const currentHistory = await this.provider.History.GetAllRecords(schema, historyTable);
@@ -633,6 +632,14 @@ export class Skyway {
         };
       }
 
+      // Reject duplicate versions before mutating anything. A collision makes
+      // the disk-by-version mapping below ambiguous (last writer in readdir
+      // order wins), so refuse rather than realign to an arbitrary file.
+      const discovered = await ScanAndResolveMigrations(
+        this.config.Migrations.Locations
+      );
+      this.assertNoDuplicateVersions(discovered);
+
       const records = await this.provider.History.GetAllRecords(schema, historyTable);
 
       // 1. Remove failed entries
@@ -647,10 +654,7 @@ export class Skyway {
         }
       }
 
-      // 2. Realign checksums
-      const discovered = await ScanAndResolveMigrations(
-        this.config.Migrations.Locations
-      );
+      // 2. Realign checksums (reuses the scan from the duplicate check above)
       const diskByVersion = new Map<string, ResolvedMigration>();
       for (const m of discovered) {
         if (m.Version) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -80,6 +80,7 @@ export {
   ResolvedMigration,
   MigrationState,
   MigrationStatus,
+  DuplicateVersionGroup,
 } from './migration/types';
 
 // ─── Migration Utilities ─────────────────────────────────────────────
@@ -90,7 +91,7 @@ export {
   ResolveMigration,
   ScanAndResolveMigrations,
 } from './migration/scanner';
-export { ResolveMigrations, ResolverResult } from './migration/resolver';
+export { ResolveMigrations, ResolverResult, DetectDuplicateMigrations } from './migration/resolver';
 
 // ─── Executor Utilities ──────────────────────────────────────────────
 export { SplitOnGO, SQLBatch } from './executor/sql-splitter';
@@ -111,6 +112,7 @@ export {
   MigrationExecutionError,
   MigrationParseError,
   ChecksumMismatchError,
+  DuplicateVersionError,
   TransactionError,
   ConnectionError,
   FailedBatchInfo,

--- a/packages/core/src/migration/resolver.ts
+++ b/packages/core/src/migration/resolver.ts
@@ -10,7 +10,12 @@
  * - Previously applied migrations are skipped
  */
 
-import { ResolvedMigration, MigrationState, MigrationStatus } from './types';
+import {
+  ResolvedMigration,
+  MigrationState,
+  MigrationStatus,
+  DuplicateVersionGroup,
+} from './types';
 import { HistoryRecord } from '../history/types';
 
 /**
@@ -343,6 +348,39 @@ export function ResolveMigrations(
     BaselineAutoSelected: baselineAutoSelected,
     BaselineFileCount: baselines.length,
   };
+}
+
+/**
+ * Finds versions claimed by more than one discovered migration file.
+ *
+ * Versioned (`V`) and baseline (`B`) files share one version namespace —
+ * both are tracked by version in the history table — so a collision can span
+ * both types. Repeatable migrations have no version and are ignored. Pure:
+ * never throws; callers decide whether to throw or report.
+ *
+ * @param discovered - All migrations found on disk
+ * @returns One group per version that appears two or more times
+ */
+export function DetectDuplicateMigrations(
+  discovered: ResolvedMigration[]
+): DuplicateVersionGroup[] {
+  const scriptsByVersion = new Map<string, string[]>();
+
+  for (const migration of discovered) {
+    if (migration.Type === 'repeatable' || migration.Version === null) continue;
+    const scripts = scriptsByVersion.get(migration.Version) ?? [];
+    scripts.push(migration.ScriptPath);
+    scriptsByVersion.set(migration.Version, scripts);
+  }
+
+  const duplicates: DuplicateVersionGroup[] = [];
+  for (const [version, scripts] of scriptsByVersion) {
+    if (scripts.length > 1) {
+      duplicates.push({ Version: version, Scripts: scripts });
+    }
+  }
+
+  return duplicates;
 }
 
 /**

--- a/packages/core/src/migration/types.ts
+++ b/packages/core/src/migration/types.ts
@@ -103,3 +103,16 @@ export interface MigrationStatus {
   /** Execution time in milliseconds, if applied */
   ExecutionTime: number | null;
 }
+
+/**
+ * A set of discovered migration files that share the same version.
+ * Versioned (`V`) and baseline (`B`) files share one version namespace,
+ * so a collision can span both types.
+ */
+export interface DuplicateVersionGroup {
+  /** The version shared by every file in the group */
+  Version: string;
+
+  /** Script paths of the colliding files */
+  Scripts: string[];
+}


### PR DESCRIPTION
## Summary

Skyway did not detect when two migration files on disk shared the same version/timestamp. Both were marked `PENDING` and **both were applied**, writing two history rows for a single version. Confirmed in a real database (`mj_duplicate`): version `202606021200` had two `SQL` rows. This PR makes Skyway **reject the collision before anything runs**, matching Flyway's `Found more than one migration with version X`.

## Root cause

- `ScanMigrations` pushed every parsed `.sql` file into an array with no dedup.
- `ResolveMigrations` built its applied-version map from **history only** — two discovered files with the same version both missed the map and both landed in `PendingMigrations`.
- The history table's primary key is `installed_rank`, not `version`, so the database never rejected the second insert. (Which duplicate got which rank was decided only by filesystem `readdir()` order — there is no meaningful "winner".)

## What changed

- **`DetectDuplicateMigrations(discovered)`** — pure, never-throwing; groups versioned (`V`) and baseline (`B`) files by version and returns any version claimed by 2+ files. `ResolveMigrations` itself is untouched.
- **`DuplicateVersionError`** (code `DUPLICATE_VERSION`) — names the colliding script paths; mirrors `ChecksumMismatchError`.
- **Fail before any DB mutation** — the scan + duplicate check now run **before** `EnsureExists` and the schema-creation marker, so a duplicate-failing `Migrate()` on a fresh database creates nothing: no schema, no history table, no rank-0 row. (Previously the guard ran after those, so "nothing applied" held only for migration rows.)
- **`Repair()` guarded** — it built a disk-by-version map with last-writer-wins on `readdir` order; it now rejects duplicates **before** removing failed entries or realigning checksums.
- **Command wiring**: `Migrate()` and `Info()` throw before resolving; `Validate()` reports the collision in `Errors`. New symbols exported from `@memberjunction/skyway-core`.

## Behavior

| Command | Before | After |
| --- | --- | --- |
| `migrate` | applied both, 2 history rows | fails fast, **0 applied**, **nothing created on a fresh DB**, names both files |
| `info` | listed both as PENDING | hard-fails with the duplicate error |
| `validate` | reported valid | invalid, lists the duplicate |
| `repair` | silently realigned to a readdir-order "winner" | refuses before mutating; reports the duplicate |

## Scope

- A duplicate = two `V`/`B` files sharing a version (V+V, B+B, or V+B — one version namespace). Repeatable (`R__`) files have no version and are unaffected.
- Detect + prevent only — existing duplicated history rows are not auto-modified.

## Testing

- **Unit (vitest):** `DetectDuplicateMigrations` + `DuplicateVersionError` (`resolver.test.ts`); `Validate()` duplicate cases (`validate.test.ts`); `migrate.test.ts` proves a fresh-DB duplicate creates **no table and no rows**; `repair.test.ts` proves duplicates are caught **before any mutation** (plus negative controls). Full suite green.
- **Real DB (SQL Server):** `integration-tests/sqlserver/duplicate-version-smoke.ts`, wired into `run.ts` — Migrate fails with 0 applied and **the history table is never created**, Info throws, Validate invalid, and removing one duplicate lets the remaining file apply. Verified end-to-end against a real instance.

## Related — cross-repo CI guard

Skyway is the migration engine for **MemberJunction/MJ**. This PR makes Skyway reject duplicates at **runtime**; the companion PR adds a **pre-merge CI guard** so duplicate migration versions can't even be committed there:

➡️ **MemberJunction/MJ#2816** — https://github.com/MemberJunction/MJ/pull/2816

Together this is defense in depth: the MJ CI check blocks duplicates at PR time, and Skyway refuses to apply them if one ever slips through. (The real MJ collision that motivated the CI guard — `202606081439` — is caught by that check.)

## Files

- **Core:** `migration/types.ts`, `migration/resolver.ts`, `core/errors.ts`, `core/skyway.ts`, `index.ts`
- **Tests:** `__tests__/resolver.test.ts`, `__tests__/validate.test.ts`, `__tests__/migrate.test.ts`, `__tests__/repair.test.ts`
- **Integration:** `integration-tests/sqlserver/duplicate-version-smoke.ts`, `integration-tests/sqlserver/run.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
