### PR TITLE
Preserve the structured detail driver errors carry, instead of only err.message

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3509,12 +3509,12 @@
     },
     "packages/cli": {
       "name": "@memberjunction/skyway-cli",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@memberjunction/skyway-core": "^0.6.0",
-        "@memberjunction/skyway-postgres": "^0.6.0",
-        "@memberjunction/skyway-sqlserver": "^0.6.0",
+        "@memberjunction/skyway-core": "^0.6.2",
+        "@memberjunction/skyway-postgres": "^0.6.2",
+        "@memberjunction/skyway-sqlserver": "^0.6.2",
         "chalk": "^4.1.2",
         "commander": "^12.1.0",
         "dotenv": "^16.4.5"
@@ -3539,7 +3539,7 @@
     },
     "packages/core": {
       "name": "@memberjunction/skyway-core",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
         "crc-32": "^1.2.2",
@@ -3555,10 +3555,10 @@
     },
     "packages/postgres": {
       "name": "@memberjunction/skyway-postgres",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@memberjunction/skyway-core": "^0.6.0",
+        "@memberjunction/skyway-core": "^0.6.2",
         "pg": "^8.13.0"
       },
       "devDependencies": {
@@ -3572,10 +3572,10 @@
     },
     "packages/sqlserver": {
       "name": "@memberjunction/skyway-sqlserver",
-      "version": "0.6.0",
+      "version": "0.6.2",
       "license": "MIT",
       "dependencies": {
-        "@memberjunction/skyway-core": "^0.6.0",
+        "@memberjunction/skyway-core": "^0.6.2",
         "mssql": "^11.0.1"
       },
       "devDependencies": {

--- a/packages/core/src/__tests__/driver-error.test.ts
+++ b/packages/core/src/__tests__/driver-error.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from 'vitest';
+import { DescribeDriverError, ExtractDriverErrorDetail } from '../executor/driver-error';
+
+/**
+ * Builds an error shaped like the one `mssql` throws — the fields live on the wrapper AND on
+ * `originalError.info`, and which one is populated depends on the failure path.
+ */
+function mssqlError(
+  message: string,
+  fields: Record<string, unknown> = {},
+  precedingErrors?: Error[]
+): Error {
+  const err = new Error(message) as Error & Record<string, unknown>;
+  err.code = 'EREQUEST';
+  err.originalError = Object.assign(new Error(message), { info: { ...fields } });
+  Object.assign(err, fields);
+  if (precedingErrors) err.precedingErrors = precedingErrors;
+  return err;
+}
+
+describe('ExtractDriverErrorDetail', () => {
+  it('reads the structured fields SQL Server reports alongside the message', () => {
+    const err = mssqlError('Transaction (Process ID 61) was deadlocked on lock resources', {
+      number: 1205,
+      class: 13,
+      state: 55,
+      procName: 'trg_OrderLine_RollupTotals',
+      lineNumber: 23,
+    });
+
+    expect(ExtractDriverErrorDetail(err)).toEqual({
+      Code: 1205,
+      Severity: 13,
+      State: 55,
+      Procedure: 'trg_OrderLine_RollupTotals',
+      Line: 23,
+    });
+  });
+
+  it('finds fields that live only on originalError.info', () => {
+    const err = new Error('Invalid column name') as Error & Record<string, unknown>;
+    err.originalError = { info: { number: 207, class: 16, procName: 'spDoThing', lineNumber: 4 } };
+
+    const detail = ExtractDriverErrorDetail(err);
+    expect(detail.Code).toBe(207);
+    expect(detail.Procedure).toBe('spDoThing');
+    expect(detail.Line).toBe(4);
+  });
+
+  it('collects preceding errors, which are the cause of a "See previous errors" summary', () => {
+    const err = mssqlError('Could not create constraint or index. See previous errors.', { number: 4902 }, [
+      new Error("Invalid column name 'RenewsSubscriptionID'."),
+      new Error("Column 'Foo' does not exist."),
+    ]);
+
+    expect(ExtractDriverErrorDetail(err).Preceding).toEqual([
+      "Invalid column name 'RenewsSubscriptionID'.",
+      "Column 'Foo' does not exist.",
+    ]);
+  });
+
+  it('returns nothing for errors that carry no structured detail', () => {
+    expect(ExtractDriverErrorDetail(new Error('plain failure'))).toEqual({});
+    expect(ExtractDriverErrorDetail('a string')).toEqual({});
+    expect(ExtractDriverErrorDetail(null)).toEqual({});
+  });
+
+  it('ignores fields that are present but unusable', () => {
+    const err = new Error('x') as Error & Record<string, unknown>;
+    Object.assign(err, { number: NaN, procName: '   ', lineNumber: 'nope' });
+    expect(ExtractDriverErrorDetail(err)).toEqual({});
+  });
+});
+
+describe('DescribeDriverError', () => {
+  it('names the procedure the error was raised in — the field that identifies the culprit', () => {
+    const err = mssqlError('Transaction (Process ID 61) was deadlocked on lock resources', {
+      number: 1205,
+      class: 13,
+      state: 55,
+      procName: 'trg_OrderLine_RollupTotals',
+      lineNumber: 23,
+    });
+
+    const described = DescribeDriverError(err);
+    expect(described).toContain('Msg 1205');
+    expect(described).toContain('Severity 13');
+    expect(described).toContain('State 55');
+    // Without this, a deadlock inside a trigger is indistinguishable from server-level instability.
+    expect(described).toContain('in trg_OrderLine_RollupTotals line 23');
+    expect(described).toContain('was deadlocked on lock resources');
+  });
+
+  it('surfaces the preceding errors instead of a pointer to output nobody kept', () => {
+    const err = mssqlError('Could not create constraint or index. See previous errors.', { number: 4902 }, [
+      new Error("Invalid column name 'RenewsSubscriptionID'."),
+    ]);
+
+    const described = DescribeDriverError(err);
+    expect(described).toContain('Preceding errors (the actual cause)');
+    expect(described).toContain("Invalid column name 'RenewsSubscriptionID'.");
+  });
+
+  it('leaves an ordinary error untouched, so it adds no noise', () => {
+    expect(DescribeDriverError(new Error('connection refused'))).toBe('connection refused');
+  });
+
+  it("ignores mssql's generic transport code but keeps a PostgreSQL SQLSTATE", () => {
+    // `EREQUEST` is identical for every mssql query failure — reporting it as a message number is
+    // noise. A PG SQLSTATE genuinely identifies the failure, so it is kept.
+    const mssql = mssqlError('Some failure', {});
+    expect(DescribeDriverError(mssql)).toBe('Some failure');
+
+    const pg = new Error('duplicate key value violates unique constraint') as Error & Record<string, unknown>;
+    pg.code = '23505';
+    expect(DescribeDriverError(pg)).toContain('Msg 23505');
+  });
+
+  it('omits the procedure clause when only a message number is known', () => {
+    const err = mssqlError('Some failure', { number: 4902 });
+    expect(DescribeDriverError(err)).toBe('Msg 4902: Some failure');
+  });
+
+  it('handles a procedure with no line number', () => {
+    const err = mssqlError('Some failure', { procName: 'spThing' });
+    expect(DescribeDriverError(err)).toBe('in spThing: Some failure');
+  });
+});

--- a/packages/core/src/core/skyway.ts
+++ b/packages/core/src/core/skyway.ts
@@ -28,6 +28,7 @@
  * await skyway.Close();
  * ```
  */
+import { DescribeDriverError } from '../executor/driver-error';
 
 import { SkywayConfig, ResolvedSkywayConfig, resolveConfig } from './config';
 import { DatabaseProvider, ProviderTransaction, HistoryInsertParams } from '../db/provider';
@@ -927,7 +928,10 @@ export class Skyway {
             await txn.Execute(batch.SQL);
           } catch (batchErr) {
             const elapsedMS = Date.now() - startTime;
-            const errorMessage = batchErr instanceof Error ? batchErr.message : String(batchErr);
+            // NOT `batchErr.message` — that drops the procedure/line the driver reported, and drops
+            // the preceding errors entirely, which is precisely what a "See previous errors"
+            // summary is pointing at. See executor/driver-error.
+            const errorMessage = DescribeDriverError(batchErr);
 
             // Extract identifiers from error and find related lines.
             // Identifier patterns are tuned for SQL Server messages but degrade

--- a/packages/core/src/executor/driver-error.ts
+++ b/packages/core/src/executor/driver-error.ts
@@ -1,0 +1,136 @@
+/**
+ * @module executor/driver-error
+ * Preserves the structured detail database drivers attach to errors, which `err.message` drops.
+ *
+ * SQL Server reports a failure as more than a sentence. `sqlcmd` prints:
+ *
+ *     Msg 1205, Level 13, State 55, Server sql, Procedure trg_OrderLine_RollupTotals, Line 23
+ *     Transaction (Process ID 61) was deadlocked on lock resources ...
+ *
+ * The `tedious`/`mssql` driver surfaces every one of those as a property on the error object, but
+ * `err.message` is only the second line. So a migration failure that is entirely explained by
+ * "Procedure trg_OrderLine_RollupTotals" arrives as an unattributed deadlock, and the reader is left
+ * to guess which of a 60,000-line script's objects was involved.
+ *
+ * Worse is the multi-error case. SQL Server frequently reports a summary whose real cause is in the
+ * messages before it:
+ *
+ *     Msg 4902 ... Could not create constraint or index. See previous errors.
+ *
+ * `mssql` collects those in `precedingErrors`, and `err.message` is exactly the line that tells you
+ * to go read the ones being discarded.
+ *
+ * This module turns the error object back into the report the driver actually gave us. It is
+ * deliberately duck-typed rather than importing `mssql`: `@skyway/core` is provider-agnostic, and
+ * PostgreSQL errors carry an analogous set of fields under different names.
+ */
+
+/** A driver error's structured fields, as far as we can identify them. */
+export interface DriverErrorDetail {
+  /** SQL Server message number (`Msg 1205`) or PostgreSQL SQLSTATE. */
+  Code?: string | number;
+  /** SQL Server severity class. */
+  Severity?: number;
+  State?: number;
+  /** The procedure, function or trigger the error was raised in — usually the most useful field. */
+  Procedure?: string;
+  /** Line number WITHIN that procedure (not within the migration file). */
+  Line?: number;
+  /** Errors SQL Server reported before this one; the cause of a "See previous errors" summary. */
+  Preceding?: string[];
+}
+
+const asNumber = (v: unknown): number | undefined =>
+  typeof v === 'number' && Number.isFinite(v) ? v : undefined;
+
+const asNonEmptyString = (v: unknown): string | undefined =>
+  typeof v === 'string' && v.trim().length > 0 ? v.trim() : undefined;
+
+/**
+ * PostgreSQL's `code` is the SQLSTATE (`23505`, `42P01`) and identifies the failure.
+ * `mssql`'s `code` is a transport-level wrapper (`EREQUEST`, `ELOGIN`) that is the same for every
+ * query failure and tells the reader nothing — reporting it as `Msg EREQUEST` is worse than
+ * reporting nothing. Only the five-character SQLSTATE shape is accepted.
+ */
+const asSqlState = (v: unknown): string | undefined => {
+  const s = asNonEmptyString(v);
+  return s && /^[0-9A-Z]{5}$/.test(s) ? s : undefined;
+};
+
+/**
+ * Pull the structured fields off a driver error.
+ *
+ * Reads both the error itself and its `originalError`, because `mssql` wraps the `tedious` error and
+ * the interesting fields live on either depending on the failure path. Returns an empty object for
+ * errors that carry nothing structured, so callers can treat "no detail" and "not a driver error"
+ * the same way.
+ */
+export function ExtractDriverErrorDetail(err: unknown): DriverErrorDetail {
+  if (err == null || typeof err !== 'object') {
+    return {};
+  }
+
+  const e = err as Record<string, unknown>;
+  const original = (e.originalError ?? {}) as Record<string, unknown>;
+  const info = (original.info ?? {}) as Record<string, unknown>;
+
+  // `number` on mssql, `code` on pg. `class` is SQL Server's severity; tedious also calls it that.
+  const pick = <T>(fn: (src: Record<string, unknown>) => T | undefined): T | undefined =>
+    fn(e) ?? fn(original) ?? fn(info);
+
+  const preceding = Array.isArray(e.precedingErrors)
+    ? (e.precedingErrors as unknown[])
+        .map((p) => (p instanceof Error ? p.message : asNonEmptyString(p)))
+        .filter((m): m is string => !!m)
+    : undefined;
+
+  const detail: DriverErrorDetail = {
+    Code: pick((s) => asNumber(s.number)) ?? asSqlState(e.code),
+    Severity: pick((s) => asNumber(s.class)),
+    State: pick((s) => asNumber(s.state)),
+    Procedure: pick((s) => asNonEmptyString(s.procName)),
+    Line: pick((s) => asNumber(s.lineNumber)),
+    Preceding: preceding && preceding.length > 0 ? preceding : undefined,
+  };
+
+  // Drop the keys we could not determine, so `Object.keys(detail).length` is a usable emptiness test.
+  for (const key of Object.keys(detail) as Array<keyof DriverErrorDetail>) {
+    if (detail[key] === undefined) {
+      delete detail[key];
+    }
+  }
+  return detail;
+}
+
+/**
+ * Render a driver error as the message plus whatever structured detail it carried.
+ *
+ * Returns the plain message unchanged when there is nothing to add, so this is safe to apply
+ * unconditionally and produces no noise for ordinary errors.
+ *
+ * @example
+ * // Msg 1205, Severity 13, State 55, in trg_OrderLine_RollupTotals line 23:
+ * // Transaction (Process ID 61) was deadlocked on lock resources ...
+ */
+export function DescribeDriverError(err: unknown): string {
+  const message = err instanceof Error ? err.message : String(err);
+  const detail = ExtractDriverErrorDetail(err);
+
+  const parts: string[] = [];
+  if (detail.Code !== undefined) parts.push(`Msg ${detail.Code}`);
+  if (detail.Severity !== undefined) parts.push(`Severity ${detail.Severity}`);
+  if (detail.State !== undefined) parts.push(`State ${detail.State}`);
+  if (detail.Procedure) {
+    parts.push(detail.Line !== undefined ? `in ${detail.Procedure} line ${detail.Line}` : `in ${detail.Procedure}`);
+  }
+
+  const prefix = parts.length > 0 ? `${parts.join(', ')}: ` : '';
+
+  // The preceding errors ARE the cause when SQL Server says "See previous errors" — put them where
+  // they cannot be missed rather than leaving the reader chasing a pointer to discarded output.
+  const preceding = detail.Preceding
+    ? `\n  Preceding errors (the actual cause):\n${detail.Preceding.map((p) => `    - ${p}`).join('\n')}`
+    : '';
+
+  return `${prefix}${message}${preceding}`;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -103,6 +103,12 @@ export {
   ContextLine,
 } from './executor/error-context';
 
+export {
+  ExtractDriverErrorDetail,
+  DescribeDriverError,
+  type DriverErrorDetail,
+} from './executor/driver-error';
+
 // ─── History Types ───────────────────────────────────────────────────
 export { HistoryRecord, HistoryRecordType } from './history/types';
 


### PR DESCRIPTION
## The problem

A migration failure loses its most useful information on the way out.

SQL Server reports a failure as more than a sentence — `sqlcmd` prints:

```
Msg 1205, Level 13, State 55, Server sql, Procedure trg_OrderLine_RollupTotals, Line 23
Transaction (Process ID 61) was deadlocked on lock resources ...
```

`mssql` puts **every one of those fields on the error object**, but `err.message` is only the second line. So skyway reports an unattributed deadlock and drops the one field that identifies the culprit. In a 60,000-line migration that's the difference between "which of my objects did this?" and hours of bisecting.

The multi-error case is worse:

```
Msg 4902 ... Could not create constraint or index. See previous errors.
```

`mssql` collects those in `precedingErrors`, and `err.message` is *precisely the line telling you to go read the ones we're discarding*. The user is pointed at output that no longer exists.

## The change

Adds `executor/driver-error`, which reads the structured fields back off the error and renders them with the message:

```
Msg 1205, Severity 13, State 55, in trg_OrderLine_RollupTotals line 23: Transaction (Process ID 61) was deadlocked ...
  Preceding errors (the actual cause):
    - Invalid column name 'RenewsSubscriptionID'.
```

One line changes in `skyway.ts` — `err.message` becomes `DescribeDriverError(err)`. `BatchInfo`, `ContextLines` and `FailedSQL` are untouched; this is purely about what the *message* carries.

## Implementation notes

- **Duck-typed rather than importing `mssql`** — `@skyway/core` is provider-agnostic, and PostgreSQL carries an analogous set of fields under different names.
- **Reads both the error and `originalError.info`**, since `mssql` wraps the `tedious` error and which one is populated depends on the failure path.
- **`mssql`'s `code` is deliberately not reported.** It's a transport wrapper (`EREQUEST`, `ELOGIN`) identical for every query failure, so `Msg EREQUEST` would be worse than nothing. A PostgreSQL SQLSTATE *is* a real identifier and is kept — the five-character shape distinguishes them. (A test caught me getting this wrong initially.)
- **Returns the message unchanged when there's nothing structured to add**, so it's safe to apply unconditionally and adds no noise to ordinary errors.

## Testing

11 new tests covering the deadlock shape, the "See previous errors" shape, fields on `originalError.info` only, the SQLSTATE-vs-transport-code distinction, and the no-op cases. Existing 196 core tests still pass.

## How this came up

Debugging a genuine migration failure in a MemberJunction app. The reported error was a bare deadlock on a single-connection run, which reads like server instability — I chased connection pooling, `MAXDOP`, and stale sessions before running the same SQL through `sqlcmd`, which named the trigger immediately. Everything needed was already on the error object.

There's a companion PR on the MJ CLI side to surface the `BatchInfo`/`ContextLines` skyway already collects but the CLI currently discards.